### PR TITLE
Rename `yolocrypto` feature to `untested`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -227,7 +227,7 @@ jobs:
           RUSTFLAGS: -D warnings
         with:
           command: test
-          args: --features=mockhsm,secp256k1,yolocrypto
+          args: --features=mockhsm,secp256k1,untested
 
   fmt:
     name: Rustfmt
@@ -279,11 +279,11 @@ jobs:
       - name: Install clippy
         run: rustup component add clippy
 
-      - name: Run cargo clippy --features=secp256k1,usb,yolocrypto
+      - name: Run cargo clippy --features=secp256k1,usb,untested
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features=secp256k1,usb,yolocrypto
+          args: --features=secp256k1,usb,untested
 
       - name: Run cargo clippy --features=mockhsm
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ http = ["harp"]
 mockhsm = ["passwords", "ring"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 setup = ["chrono", "passwords", "serde_json", "uuid/serde"]
+untested = ["sha2"]
 usb = ["rusb"]
-yolocrypto = ["sha2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ supported, please open an issue requesting support.
 
 NOTE: Commands marked ⚠️ have not been properly tested and may contain bugs or
 not work at all. They are disabled by default: to use them you must enable the
-`yolocrypto` cargo feature. If you do get them to work, please open an issue
+`untested` cargo feature. If you do get them to work, please open an issue
 (or PR) reporting success so we can promote them to ✅.
 
 ## Testing

--- a/src/client.rs
+++ b/src/client.rs
@@ -40,7 +40,7 @@ use std::{
 };
 #[cfg(feature = "passwords")]
 use std::{thread, time::SystemTime};
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 use {
     crate::{
         algorithm::Algorithm,
@@ -211,10 +211,10 @@ impl Client {
     /// **WARNING**: This functionality has not been tested and has not yet been
     /// confirmed to actually work! USE AT YOUR OWN RISK!
     ///
-    /// You will need to enable the `yolocrypto` cargo feature to use it.
+    /// You will need to enable the `untested` cargo feature to use it.
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Derive_Ecdh.html>
-    #[cfg(feature = "yolocrypto")]
+    #[cfg(feature = "untested")]
     pub fn derive_ecdh(
         &self,
         key_id: object::Id,
@@ -960,10 +960,10 @@ impl Client {
     /// **WARNING**: This functionality has not been tested and has not yet been
     /// confirmed to actually work! USE AT YOUR OWN RISK!
     ///
-    /// You will need to enable the `yolocrypto` cargo feature to use it.
+    /// You will need to enable the `untested` cargo feature to use it.
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Pkcs1.html>
-    #[cfg(feature = "yolocrypto")]
+    #[cfg(feature = "untested")]
     pub fn sign_rsa_pkcs1v15_sha256(
         &self,
         key_id: object::Id,
@@ -982,10 +982,10 @@ impl Client {
     /// **WARNING**: This functionality has not been tested and has not yet been
     /// confirmed to actually work! USE AT YOUR OWN RISK!
     ///
-    /// You will need to enable the `yolocrypto` cargo feature to use it.
+    /// You will need to enable the `untested` cargo feature to use it.
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Pss.html>
-    #[cfg(feature = "yolocrypto")]
+    #[cfg(feature = "untested")]
     pub fn sign_rsa_pss_sha256(
         &self,
         key_id: object::Id,
@@ -1020,10 +1020,10 @@ impl Client {
     /// **WARNING**: This functionality has not been tested and has not yet been
     /// confirmed to actually work! USE AT YOUR OWN RISK!
     ///
-    /// You will need to enable the `yolocrypto` cargo feature to use it.
+    /// You will need to enable the `untested` cargo feature to use it.
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Ssh_Certificate.html>
-    #[cfg(feature = "yolocrypto")]
+    #[cfg(feature = "untested")]
     pub fn sign_ssh_certificate<A>(
         &self,
         key_id: object::Id,

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -3,12 +3,12 @@
 //! **WARNING**: This functionality has not been tested and has not yet been
 //! confirmed to actually work! USE AT YOUR OWN RISK!
 //!
-//! You will need to enable the `yolocrypto` cargo feature to use it.
+//! You will need to enable the `untested` cargo feature to use it.
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/Derive_Ecdh.html>
 
 mod algorithm;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub(crate) mod commands;
 mod point;
 

--- a/src/ecdh/commands.rs
+++ b/src/ecdh/commands.rs
@@ -3,7 +3,7 @@
 //! **WARNING**: This functionality has not been tested and has not yet been
 //! confirmed to actually work! USE AT YOUR OWN RISK!
 //!
-//! You will need to enable the `yolocrypto` cargo feature to use it.
+//! You will need to enable the `untested` cargo feature to use it.
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/Derive_Ecdh.html>
 

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -2,7 +2,7 @@
 //! (signing/encryption).
 //!
 //! NOTE: This functionality has not been properly tested and is therefore
-//! not enabled by default! Enable the `yolocrypto` cargo feature if you would
+//! not enabled by default! Enable the `untested` cargo feature if you would
 //! like to use it (please report success or bugs!)
 
 // TODO(tarcieri): finalize and test RSA support

--- a/src/rsa/pkcs1.rs
+++ b/src/rsa/pkcs1.rs
@@ -4,11 +4,11 @@
 //! non-RSA algorithms like Ed25519 or ECDSA, or RSA-PSS if RSA is required.
 
 mod algorithm;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub(crate) mod commands;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 mod signature;
 
 pub use self::algorithm::Algorithm;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub use self::signature::Signature;

--- a/src/rsa/pss.rs
+++ b/src/rsa/pss.rs
@@ -2,15 +2,15 @@
 //! primitives with the EMSA-PSS encoding method.
 
 mod algorithm;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub(crate) mod commands;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 mod signature;
 
 /// Maximum message size supported for RSASSA-PSS
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub const MAX_MESSAGE_SIZE: usize = 0xFFFF;
 
 pub use self::algorithm::Algorithm;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub use self::signature::Signature;

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -3,10 +3,10 @@
 //! **WARNING**: This functionality has not been tested and has not yet been
 //! confirmed to actually work! USE AT YOUR OWN RISK!
 //!
-//! You will need to enable the `yolocrypto` cargo feature to use it.
+//! You will need to enable the `untested` cargo feature to use it.
 
 mod certificate;
-#[cfg(feature = "yolocrypto")]
+#[cfg(feature = "untested")]
 pub(crate) mod commands;
 mod template;
 

--- a/src/ssh/commands.rs
+++ b/src/ssh/commands.rs
@@ -3,7 +3,7 @@
 //! **WARNING**: This functionality has not been tested and has not yet been
 //! confirmed to actually work! USE AT YOUR OWN RISK!
 //!
-//! You will need to enable the `yolocrypto` cargo feature to use it.
+//! You will need to enable the `untested` cargo feature to use it.
 
 use crate::{
     algorithm::Algorithm,


### PR DESCRIPTION
There's not a cryptographic risk in these APIs per se: they simply won't work if they haven't been implemented correctly.