### PR TITLE
v0.32.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.32.1] (2020-03-24)
+
+- connector/usb: Use `rusb::Context` instead of `GlobalContext` ([#15])
+
+[0.32.1]: https://github.com/iqlusioninc/yubihsm.rs/pull/16
+[#15]: https://github.com/iqlusioninc/yubihsm.rs/pull/15
+
 ## [0.32.0] (2020-02-29)
 
 - Rename `yolocrypto` feature to `untested` ([#5])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "aes",
  "anomaly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.32.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.32.1" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/src/connector/usb.rs
+++ b/src/connector/usb.rs
@@ -1,6 +1,12 @@
 //! Support for connecting to the YubiHSM 2 via USB.
 //!
-//! The [yubihsm::connector::usb::Devices] can be used to
+//! Typically to access a YubiHSM 2 via USB, you'll use the [`Connector::usb`]
+//! method in the event there is only one expected to be connected at a time.
+//!
+//! To enumerate available USB devices (e.g. in the case there is more than
+//! one YubiHSM connected to the same computer), use [`Devices`].
+//!
+//! [`Connector::usb`]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.usb
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.32.0"
+    html_root_url = "https://docs.rs/yubihsm/0.32.1"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- connector/usb: Use `rusb::Context` instead of `GlobalContext` ([#15])

[#15]: https://github.com/iqlusioninc/yubihsm.rs/pull/15