### PR TITLE
v0.33.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.33.0] (2020-04-20)
+
+- Upgrade to `signature` crate v1.0; `ecdsa` crate v0.5 ([#24])
+- Bump `tiny_http` from 0.6 to 0.7 ([#23])
+
+[0.33.0]: https://github.com/iqlusioninc/yubihsm.rs/pull/26
+[#24]: https://github.com/iqlusioninc/yubihsm.rs/pull/24
+[#23]: https://github.com/iqlusioninc/yubihsm.rs/pull/23
+
 ## [0.32.1] (2020-03-24)
 
 - connector/usb: Use `rusb::Context` instead of `GlobalContext` ([#15])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "aes",
  "anomaly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.32.1" # Also update html_root_url in lib.rs when bumping this
+version       = "0.33.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality
@@ -17,7 +17,7 @@ edition       = "2018"
 
 [dependencies]
 aes = "0.3"
-anomaly = "0.2.0"
+anomaly = "0.2"
 bitflags = "1"
 block-modes = "0.3"
 chrono = { version = "0.4", features=["serde"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.32.1"
+    html_root_url = "https://docs.rs/yubihsm/0.33.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Upgrade to `signature` crate v1.0; `ecdsa` crate v0.5 ([#24])
- Bump `tiny_http` from 0.6 to 0.7 ([#23])

[#24]: https://github.com/iqlusioninc/yubihsm.rs/pull/24
[#23]: https://github.com/iqlusioninc/yubihsm.rs/pull/23