### PR TITLE
Replace `actions-rs/audit-check` with direct `cargo audit` invocation

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -18,8 +18,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.11.2
-      - uses: actions-rs/audit-check@v1
+          key: ${{ runner.os }}-cargo-audit-v0.12.1
+      - uses: actions-rs/toolchain@v1
         with:
-          args: --ignore RUSTSEC-2019-0031
-          token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
+          override: true
+      - name: Install cargo audit
+        run: cargo install cargo-audit
+      - name: Run cargo audit
+        run: cargo audit --deny-warnings --ignore RUSTSEC-2020-0031

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,9 +465,9 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9cc9ec2c11b93118b4f8dc0665a3741bc90121d44dc0410f899274c5745454c"
+checksum = "8677f2d5ab29b5a4815aabd2ddb83e1899e58903a67594406893a9757f48ccae"
 dependencies = [
  "bitvec",
  "const-oid",


### PR DESCRIPTION
Unfortunately we can't pass an `--ignore` option to cargo-audit via `actions-rs/audit-check` to ignore the request smuggling vulnerability in `tiny_http` due to this issue:

https://github.com/actions-rs/audit-check/issues/132

This PR switches to invoking `cargo audit` directly so we can.