### PR TITLE
Add support for k256::ecdsa::recoverable::Signature

### DIFF
--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -122,3 +122,16 @@ where
         Ok(signature)
     }
 }
+
+#[cfg(feature = "secp256k1")]
+impl<D> DigestSigner<D, k256::ecdsa::recoverable::Signature> for Signer<Secp256k1>
+where
+    D: Digest<OutputSize = U32> + Clone + Default,
+{
+    /// Compute an Ethereum-style ECDSA/secp256k1 signature of the given digest
+    fn try_sign_digest(&self, digest: D) -> Result<k256::ecdsa::recoverable::Signature, Error> {
+        let pk = k256::ecdsa::VerifyKey::from_encoded_point(&self.public_key)?;
+        let sig = self.try_sign_digest(digest.clone())?;
+        k256::ecdsa::recoverable::Signature::from_digest_trial_recovery(&pk, digest, &sig)
+    }
+}


### PR DESCRIPTION
Support for creating Ethereum-style recoverable ECDSA/secp256k1 signatures.