### PR TITLE
Use `elliptic_curve::EncodedPoint::to_untagged_bytes()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,9 +465,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8677f2d5ab29b5a4815aabd2ddb83e1899e58903a67594406893a9757f48ccae"
+checksum = "82e7e174baa250269c92f2e0d59abaeb14c7d8072abd130dee996cc61141825a"
 dependencies = [
  "bitvec",
  "const-oid",
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e163af5c3d73a042455736aab29d9e98c7592f59ea5d3faf4a715fc4b8d36c2"
+checksum = "fb737ace8aba588f48f94ffdada8872a29a658244e9d2b5a7ce8f1283c35df86"
 dependencies = [
  "cfg-if",
  "ecdsa",

--- a/src/mockhsm/object/payload.rs
+++ b/src/mockhsm/object/payload.rs
@@ -129,10 +129,14 @@ impl Payload {
     pub fn public_key_bytes(&self) -> Option<Vec<u8>> {
         match self {
             Payload::EcdsaNistP256(secret_key) => {
-                Some(p256::EncodedPoint::from_secret_key(secret_key, false).as_bytes()[1..].into())
+                p256::EncodedPoint::from_secret_key(secret_key, false)
+                    .to_untagged_bytes()
+                    .map(|b| b.to_vec())
             }
             Payload::EcdsaSecp256k1(secret_key) => {
-                Some(k256::EncodedPoint::from_secret_key(secret_key, false).as_bytes()[1..].into())
+                k256::EncodedPoint::from_secret_key(secret_key, false)
+                    .to_untagged_bytes()
+                    .map(|b| b.to_vec())
             }
             Payload::Ed25519Key(secret_key) => {
                 Some(ed25519::PublicKey::from(secret_key).as_ref().into())


### PR DESCRIPTION
Uses a method that strips the tag byte