### PR TITLE
Add more `doc_cfg`

### DIFF
--- a/src/authentication/credentials.rs
+++ b/src/authentication/credentials.rs
@@ -29,6 +29,7 @@ impl Credentials {
     /// (PBKDF2 + static salt), which is not particularly strong, so use
     /// of a long, random password is recommended.
     #[cfg(feature = "passwords")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "passwords")))]
     pub fn from_password(authentication_key_id: object::Id, password: &[u8]) -> Self {
         Self::new(
             authentication_key_id,
@@ -38,6 +39,7 @@ impl Credentials {
 }
 
 #[cfg(feature = "passwords")]
+#[cfg_attr(docsrs, doc(cfg(feature = "passwords")))]
 impl Default for Credentials {
     fn default() -> Self {
         Self::new(

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -45,6 +45,7 @@ impl Key {
     /// you use a long, random password when using this method as the key
     /// derivation algorithm used does little to prevent brute force attacks.
     #[cfg(feature = "passwords")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "passwords")))]
     pub fn derive_from_password(password: &[u8]) -> Self {
         let mut kdf_output = [0u8; SIZE];
         pbkdf2::<Hmac<Sha256>>(password, PBKDF2_SALT, PBKDF2_ITERATIONS, &mut kdf_output);
@@ -98,6 +99,7 @@ impl Debug for Key {
 
 /// Derive the default authentication key for all YubiHSM 2s
 #[cfg(feature = "passwords")]
+#[cfg_attr(docsrs, doc(cfg(feature = "passwords")))]
 impl Default for Key {
     fn default() -> Self {
         Key::derive_from_password(DEFAULT_PASSWORD)

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,8 +38,10 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
+
 #[cfg(feature = "passwords")]
 use std::{thread, time::SystemTime};
+
 #[cfg(feature = "untested")]
 use {
     crate::{
@@ -50,6 +52,9 @@ use {
     },
     sha2::{Digest, Sha256},
 };
+
+#[cfg(docsrs)]
+use crate::ecdsa;
 
 /// YubiHSM client: main API in this crate for accessing functions of the
 /// HSM hardware device.
@@ -215,6 +220,7 @@ impl Client {
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Derive_Ecdh.html>
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn derive_ecdh(
         &self,
         key_id: object::Id,
@@ -959,6 +965,7 @@ impl Client {
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Pkcs1.html>
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn sign_rsa_pkcs1v15_sha256(
         &self,
         key_id: object::Id,
@@ -981,6 +988,7 @@ impl Client {
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Pss.html>
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn sign_rsa_pss_sha256(
         &self,
         key_id: object::Id,
@@ -1019,6 +1027,7 @@ impl Client {
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Ssh_Certificate.html>
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn sign_ssh_certificate<A>(
         &self,
         key_id: object::Id,

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -20,19 +20,23 @@ mod error;
 mod connectable;
 mod connection;
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod http;
 mod message;
 #[cfg(feature = "usb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "usb")))]
 pub mod usb;
 
 pub use self::connection::Connection;
 pub use self::error::*;
+
 pub(crate) use self::{connectable::Connectable, message::Message};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 #[cfg(feature = "http")]
 pub use self::http::HttpConfig;
+
 #[cfg(feature = "http")]
 use self::http::HttpConnector;
 
@@ -56,6 +60,7 @@ pub struct Connector {
 impl Connector {
     /// Create a new HTTP connector
     #[cfg(feature = "http")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http")))]
     pub fn http(config: &HttpConfig) -> Self {
         Self::from(HttpConnector::create(config))
     }
@@ -66,8 +71,17 @@ impl Connector {
     ///
     /// [yubihsm::connector::usb]: https://docs.rs/yubihsm/latest/yubihsm/connector/usb/index.html
     #[cfg(feature = "usb")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "usb")))]
     pub fn usb(config: &UsbConfig) -> Self {
         Self::from(UsbConnector::create(config))
+    }
+
+    /// Create a mock HSM connector (useful for testing)
+    #[cfg(feature = "mockhsm")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "mockhsm")))]
+    pub fn mockhsm() -> Self {
+        let mockhsm: Box<dyn Connectable> = MockHsm::new().into();
+        Self::from(mockhsm)
     }
 
     /// Send a command message to the HSM, then read and return the response
@@ -87,13 +101,6 @@ impl Connector {
                 *connection = None;
                 e
             })
-    }
-
-    /// Create a mock HSM connector (useful for testing)
-    #[cfg(feature = "mockhsm")]
-    pub fn mockhsm() -> Self {
-        let mockhsm: Box<dyn Connectable> = MockHsm::new().into();
-        Self::from(mockhsm)
     }
 }
 

--- a/src/connector/http/config.rs
+++ b/src/connector/http/config.rs
@@ -8,6 +8,7 @@ pub const DEFAULT_TIMEOUT_MILLIS: u64 = 5000;
 
 /// Configuration options for the HTTP (i.e. `yubihsm-connector`) connection
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub struct HttpConfig {
     /// Address of `yubihsm-connector` (IP address or DNS name)
     pub addr: String,

--- a/src/connector/usb/config.rs
+++ b/src/connector/usb/config.rs
@@ -8,6 +8,7 @@ pub const DEFAULT_TIMEOUT_MILLIS: u64 = 1000;
 
 /// Configuration for connecting to the YubiHSM via USB
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(docsrs, doc(cfg(feature = "usb")))]
 pub struct UsbConfig {
     /// Serial number of the YubiHSM to connect to
     pub serial: Option<SerialNumber>,

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -5,6 +5,7 @@ pub mod nistp256;
 pub mod nistp384;
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub mod secp256k1;
 
 pub(crate) mod commands;
@@ -14,4 +15,5 @@ pub use self::{algorithm::Algorithm, nistp256::NistP256, nistp384::NistP384, sig
 pub use ::ecdsa::{asn1, elliptic_curve::sec1, signature, Signature};
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub use self::secp256k1::Secp256k1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! The following is an example of how to create a [yubihsm::Client] by
 //! connecting via USB, and then performing an Ed25519 signature:
 //!
-//! ```no_build
+//! ```ignore
 //! use yubihsm::{Client, Credentials, UsbConnector};
 //!
 //! // Connect to the first YubiHSM 2 we detect
@@ -93,6 +93,7 @@ pub mod response;
 pub mod rsa;
 pub mod session;
 #[cfg(feature = "setup")]
+#[cfg_attr(docsrs, doc(cfg(feature = "setup")))]
 pub mod setup;
 pub mod ssh;
 pub mod template;


### PR DESCRIPTION
Documents which cargo features must be enabled to use different parts of the API.