### PR TITLE
Bump RustCrypto dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,33 +32,33 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher",
+ "cipher",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+checksum = "8c5ab1fa47ce0ddf44cbd65b1b4e626e3c03b06fd42005603acdc6fa13526296"
 dependencies = [
- "block-cipher",
  "byteorder",
+ "cipher",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
 ]
 
@@ -136,22 +136,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block-modes"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
+checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
 dependencies = [
- "block-cipher",
  "block-padding",
+ "cipher",
 ]
 
 [[package]]
@@ -201,12 +192,12 @@ checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "ccm"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbba800a6a55058ecb75c7a42e3d16a715a2b1f1afa9acf07365d6ab30d62ce1"
+checksum = "5aca1a8fbc20b50ac9673ff014abfb2b5f4085ee1a850d408f14a159c5853ac7"
 dependencies = [
  "aead",
- "block-cipher",
+ "cipher",
  "subtle",
 ]
 
@@ -235,6 +226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d29eb15132782371f71da8f947dba48b3717bdb6fa771b9b434d645e40a7193"
 
 [[package]]
+name = "cipher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,11 +247,11 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5220604fe5c112e2851b00da795c72cbb71bf112f2cbd532bdcfb4106eeb320b"
+checksum = "73d4de4f7724e5fe70addfb2bd37c2abd2f95084a429d7773b0b9645499b4272"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
  "dbl",
 ]
 
@@ -365,7 +365,17 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "block-cipher",
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "cipher",
  "generic-array",
  "subtle",
 ]
@@ -430,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b586654f7964785521b07db8e9a02ca2361ceb0ca82bef37226faa091049487"
 dependencies = [
  "elliptic-curve",
- "hmac",
+ "hmac 0.9.0",
  "signature",
 ]
 
@@ -574,7 +584,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.9.1",
+ "digest",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.0",
  "digest",
 ]
 
@@ -792,11 +812,11 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170d73bf11f39b4ce1809aabc95bf5c33564cdc16fc3200ddda17a5f6e5e48b"
+checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
 ]
 
 [[package]]
@@ -1433,7 +1453,7 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "harp",
- "hmac",
+ "hmac 0.10.1",
  "k256",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,30 +16,30 @@ keywords      = ["ecdsa", "ed25519", "hmac", "hsm", "yubikey"]
 edition       = "2018"
 
 [dependencies]
-aes = "0.5"
+aes = "0.6"
 anomaly = "0.2"
 bitflags = "1"
-block-modes = "0.6"
-ccm = { version = "0.2", optional = true, features = ["std"] }
+block-modes = "0.7"
+ccm = { version = "0.3", optional = true, features = ["std"] }
 chrono = { version = "0.4", features = ["serde"], optional = true }
-cmac = "0.4"
+cmac = "0.5"
 digest = { version = "0.9", optional = true, default-features = false }
 ecdsa = { version = "0.8", default-features = false }
 ed25519 = "1"
 ed25519-dalek = { version = "1", optional = true }
 harp = { version = "0.1", optional = true }
-hmac = { version = "0.9", optional = true }
+hmac = { version = "0.10", optional = true }
 k256 = { version = "0.5", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
 p256 = { version = "0.5", default-features = false, features = ["ecdsa-core"] }
 p384 = { version = "0.4", default-features = false, features = ["ecdsa"] }
-pbkdf2 = { version = "0.5", optional = true, default-features = false }
+pbkdf2 = { version = "0.6", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
 rand_core = { version = "0.5", features = ["std"] }
 rusb = { version = "0.6", optional = true }
 sha2 = { version = "0.9", optional = true }
-signature = { version = "1", features = ["derive-preview"] }
+signature = { version = "1.2.0", features = ["derive-preview"] }
 subtle = "2"
 thiserror = "1"
 tiny_http = { version = "0.7", optional = true }

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -8,7 +8,7 @@ use crate::{
     serialization::{deserialize, serialize},
     wrap, Algorithm, Capability, Domain,
 };
-use aes::block_cipher::consts::{U13, U8};
+use aes::cipher::consts::{U13, U8};
 use anomaly::{fail, format_err};
 use ccm::aead::{AeadInPlace, NewAead};
 use std::collections::{btree_map::Iter as MapIter, BTreeMap as Map};

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -40,10 +40,7 @@ use crate::{
     session::{self, ErrorKind},
 };
 use aes::{
-    block_cipher::{
-        generic_array::{typenum::U16, GenericArray},
-        BlockCipher, NewBlockCipher,
-    },
+    cipher::{consts::U16, generic_array::GenericArray, BlockCipher, NewBlockCipher},
     Aes128,
 };
 use anomaly::{fail, format_err};


### PR DESCRIPTION
Bumps the following RustCrypto crates, which now leverage the new `cipher` crate as a root dependency:

- `aes` v0.6
- `block-modes` v0.7
- `ccm` v0.3
- `cmac` v0.5
- `hmac` v0.10
- `pbkdf2` v0.6