### PR TITLE
v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.35.0 (2020-10-19)
+### Added
+- Support for k256::ecdsa::recoverable::Signature ([#95])
+
+### Changed
+- Bump RustCrypto dependencies ([#82], [#116])
+
+### Removed
+- Signatory-based types ([#91])
+
+[#116]: https://github.com/iqlusioninc/yubihsm.rs/pull/116
+[#95]: https://github.com/iqlusioninc/yubihsm.rs/pull/95
+[#91]: https://github.com/iqlusioninc/yubihsm.rs/pull/91
+[#82]: https://github.com/iqlusioninc/yubihsm.rs/pull/82
+
 ## 0.34.0 (2020-06-18)
 ### Changed
 - Update `signatory` to v0.20 ([#56])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.35.0-rc"
+version = "0.35.0"
 dependencies = [
  "aes",
  "anomaly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.35.0-rc" # Also update html_root_url in lib.rs when bumping this
+version       = "0.35.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.35.0-rc"
+    html_root_url = "https://docs.rs/yubihsm/0.35.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Added
- Support for k256::ecdsa::recoverable::Signature ([#95])

### Changed
- Bump RustCrypto dependencies ([#82], [#116])

### Removed
- Signatory-based types ([#91])

[#116]: https://github.com/iqlusioninc/yubihsm.rs/pull/116
[#95]: https://github.com/iqlusioninc/yubihsm.rs/pull/95
[#91]: https://github.com/iqlusioninc/yubihsm.rs/pull/91
[#82]: https://github.com/iqlusioninc/yubihsm.rs/pull/82