### PR TITLE
v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.36.0 (2020-12-07)
+### Changed
+- Bump `ecdsa` crate dependency to v0.9; MSRV 1.46+ ([#130])
+
+[#130]: https://github.com/iqlusioninc/yubihsm.rs/pull/130
+
 ## 0.35.0 (2020-10-19)
 ### Added
 - Support for k256::ecdsa::recoverable::Signature ([#95])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aes",
  "anomaly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.35.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.36.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Prerequisites
 
-Minimum Supported Rust Version: Rust 1.46+.
+Minimum Supported Rust Version: Rust **1.46**+.
 
 On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
 secure communication with the YubiHSM:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.35.0"
+    html_root_url = "https://docs.rs/yubihsm/0.36.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Changed
- Bump `ecdsa` crate dependency to v0.9; MSRV 1.46+ ([#130])

[#130]: https://github.com/iqlusioninc/yubihsm.rs/pull/130