### PR TITLE
v0.38.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,0 @@
-# https://github.com/RustSec/cargo-audit/blob/master/audit.toml.example
-
-[advisories]
-ignore = ["RUSTSEC-2020-0031"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.38.0 (2021-02-02)
+### Changed
+- Bump `tiny_http` dependency to 0.8.0; fixes `RUSTSEC-2020-0031` ([#158])
+- Bump `pbkdf2` dependency to v0.7 ([#162])
+
+[#158]: https://github.com/iqlusioninc/yubihsm.rs/pull/158
+[#162]: https://github.com/iqlusioninc/yubihsm.rs/pull/162
+
 ## 0.37.0 (2020-12-22)
 ### Changed
 - Bump `ecdsa` crate to v0.10 ([#141])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yubihsm"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aes",
  "anomaly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.37.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.38.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.37.0"
+    html_root_url = "https://docs.rs/yubihsm/0.38.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
- Bump `tiny_http` dependency to 0.8.0; fixes `RUSTSEC-2020-0031` ([#158])
- Bump `pbkdf2` dependency to v0.7 ([#162])

[#158]: https://github.com/iqlusioninc/yubihsm.rs/pull/158
[#162]: https://github.com/iqlusioninc/yubihsm.rs/pull/162