### PR TITLE
RustCrypto dependency updates; MSRV 1.49+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.46.0 # MSRV
+          - 1.49.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -56,7 +56,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.46.0 # MSRV
+          - 1.49.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -100,7 +100,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.46.0 # MSRV
+          toolchain: 1.49.0 # MSRV
           components: clippy
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,41 +19,22 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "8aeaececfd937b9762778f2aca063ad24fdc827c48c07aeae36fb20c03afa11a"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+checksum = "99446914425f48a667458b33c7fb920e24cf9e7c149a072a9fc420731b353835"
 dependencies = [
- "aes-soft",
- "aesni",
+ "cfg-if",
  "cipher",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
+ "cpufeatures",
  "opaque-debug",
 ]
 
@@ -111,12 +92,13 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.18.5"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
  "radium",
+ "tap",
  "wyz",
 ]
 
@@ -132,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
+checksum = "783474235dae38fb23b124e596ac32b20c4cca908ae9c7bc88d63773dded444c"
 dependencies = [
  "block-padding",
  "cipher",
@@ -187,9 +169,9 @@ checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "ccm"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca1a8fbc20b50ac9673ff014abfb2b5f4085ee1a850d408f14a159c5853ac7"
+checksum = "62540fbe7b9f9280047764363ab3004301fea9a7822af5bea350826a24ab42d1"
 dependencies = [
  "aead",
  "cipher",
@@ -224,9 +206,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
 ]
@@ -244,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d4de4f7724e5fe70addfb2bd37c2abd2f95084a429d7773b0b9645499b4272"
+checksum = "b70e37282d9624283878ffda1d1e53883bcf868cf441bddda44127620b39572d"
 dependencies = [
  "crypto-mac",
  "dbl",
@@ -254,9 +236,15 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda"
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
 
 [[package]]
 name = "cpuid-bool"
@@ -347,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "cipher",
  "generic-array",
@@ -386,7 +374,7 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -402,11 +390,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "83dc83d0b59f92103d8e661e60526338ad3aeb0c15fa4a29a14b6a9b1ac8a43c"
 dependencies = [
  "const-oid",
+ "typenum",
 ]
 
 [[package]]
@@ -420,10 +409,11 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -460,30 +450,28 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "ee681bf25de1aad7cd02ccc7525d7b4bfab7be2493dbe3ee18d93f86eb3dcf3e"
 dependencies = [
  "bitvec",
- "digest",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.2",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.2",
  "subtle",
 ]
 
@@ -525,6 +513,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,12 +531,12 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.2",
  "subtle",
 ]
 
@@ -564,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -618,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4476a0808212a9e81ce802eb1a0cfc60e73aea296553bacc0fac7e1268bc572a"
+checksum = "8b7438a0fa4939493ae40cc673936c557b9b8a654d258f603fee647b62085ff0"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -748,9 +747,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adcc06fe90ec8fb2d2ad46746d2cbd639b158d4240364aa832da7e263dbee91"
+checksum = "1cf301f7f053902eaf046d541cd7b454a588b2bdd571f18195b57ae197aed2cb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -759,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea33960aac2200d19a5c9ab06a11ebd48a37a23144496632c358182e6765d80b"
+checksum = "94e3bfd7d8f202c293072de214ad93480b533985bfee4fa4a13cfdd185fab13d"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -769,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac",
 ]
@@ -784,11 +783,12 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "b813f58dc6e5d1820868a3c3df3a7ae7852aa2d3d18e98f0d6b20ddd01fe25d7"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.3.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -861,10 +861,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_hc",
 ]
 
@@ -875,7 +875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -884,7 +884,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -893,7 +902,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1074,25 +1083,34 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.2",
  "signature_derive",
 ]
 
 [[package]]
 name = "signature_derive"
-version = "1.0.0-pre.2"
+version = "1.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
+checksum = "ffba76095b73f87680d2cf325a8000d5fc507ca6c20c4f7e2747405550620d90"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "spki"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -1123,6 +1141,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
@@ -1419,7 +1443,7 @@ dependencies = [
  "p256",
  "p384",
  "pbkdf2",
- "rand_core",
+ "rand_core 0.6.2",
  "rusb",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,27 +16,27 @@ keywords      = ["ecdsa", "ed25519", "hmac", "hsm", "yubikey"]
 edition       = "2018"
 
 [dependencies]
-aes = "0.6"
+aes = "0.7"
 anomaly = "0.2"
 bitflags = "1"
-block-modes = "0.7"
-ccm = { version = "0.3", optional = true, features = ["std"] }
+block-modes = "0.8"
+ccm = { version = "0.4", optional = true, features = ["std"] }
 chrono = { version = "0.4", features = ["serde"], optional = true }
-cmac = "0.5"
+cmac = "0.6"
 digest = { version = "0.9", optional = true, default-features = false }
-ecdsa = { version = "0.10", default-features = false }
+ecdsa = { version = "0.11", default-features = false }
 ed25519 = "1"
 ed25519-dalek = { version = "1", optional = true }
 harp = { version = "0.1", optional = true }
-hmac = { version = "0.10", optional = true }
-k256 = { version = "0.7", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
+hmac = { version = "0.11", optional = true }
+k256 = { version = "0.8", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
-p256 = { version = "0.7", default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.6", default-features = false, features = ["ecdsa"] }
-pbkdf2 = { version = "0.7", optional = true, default-features = false }
+p256 = { version = "0.8", default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.7", default-features = false, features = ["ecdsa"] }
+pbkdf2 = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
-rand_core = { version = "0.5", features = ["std"] }
+rand_core = { version = "0.6", features = ["std"] }
 rusb = { version = "0.8", optional = true }
 sha2 = { version = "0.9", optional = true }
 signature = { version = "1.2.0", features = ["derive-preview"] }
@@ -50,7 +50,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 criterion = "0.3"
 ed25519-dalek = "1"
 lazy_static = "1"
-p256 = { version = "0.7", features = ["ecdsa"] }
+p256 = { version = "0.8", features = ["ecdsa"] }
 
 [features]
 default = ["http", "passwords", "setup"]

--- a/src/asymmetric/public_key.rs
+++ b/src/asymmetric/public_key.rs
@@ -1,15 +1,13 @@
 //! Public keys for use with asymmetric cryptography / signatures
 
 use crate::{asymmetric, ecdsa::algorithm::CurveAlgorithm, ed25519};
-use ::ecdsa::{
-    elliptic_curve::{
-        sec1::{self, UncompressedPointSize, UntaggedPointSize},
-        weierstrass::{point, Curve},
-    },
+use ::ecdsa::elliptic_curve::{
     generic_array::{
         typenum::{Unsigned, U1},
         ArrayLength, GenericArray,
     },
+    sec1::{self, UncompressedPointSize, UntaggedPointSize},
+    weierstrass::{Curve, PointCompression},
 };
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
@@ -55,7 +53,7 @@ impl PublicKey {
     /// Return the ECDSA public key of the given curve type if applicable
     pub fn ecdsa<C>(&self) -> Option<sec1::EncodedPoint<C>>
     where
-        C: Curve + CurveAlgorithm + point::Compression,
+        C: Curve + CurveAlgorithm + PointCompression,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {

--- a/src/client.rs
+++ b/src/client.rs
@@ -347,7 +347,7 @@ impl Client {
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Get_Log_Entries.html>
     pub fn get_log_entries(&self) -> Result<LogEntries, Error> {
-        Ok(self.send_command(GetLogEntriesCommand {})?)
+        self.send_command(GetLogEntriesCommand {})
     }
 
     /// Get information about an object.
@@ -899,10 +899,10 @@ impl Client {
         key_id: object::Id,
         attestation_key_id: Option<object::Id>,
     ) -> Result<attestation::Certificate, Error> {
-        Ok(self.send_command(SignAttestationCertificateCommand {
+        self.send_command(SignAttestationCertificateCommand {
             key_id,
             attestation_key_id: attestation_key_id.unwrap_or(0),
-        })?)
+        })
     }
 
     /// Compute an ECDSA signature of the given digest (i.e. a precomputed SHA-2 digest)

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -12,7 +12,7 @@ pub(crate) mod commands;
 mod signer;
 
 pub use self::{algorithm::Algorithm, nistp256::NistP256, nistp384::NistP384, signer::Signer};
-pub use ::ecdsa::{asn1, elliptic_curve::sec1, signature, Signature};
+pub use ::ecdsa::{der, elliptic_curve::sec1, signature, Signature};
 
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -9,7 +9,7 @@ use ::ecdsa::{
         consts::{U1, U32},
         generic_array::ArrayLength,
         sec1::{self, UncompressedPointSize, UntaggedPointSize},
-        weierstrass::{point, Curve},
+        weierstrass::{Curve, PointCompression},
     },
     Signature,
 };
@@ -24,7 +24,7 @@ use super::Secp256k1;
 #[derive(signature::Signer)]
 pub struct Signer<C>
 where
-    C: Curve + CurveAlgorithm + point::Compression,
+    C: Curve + CurveAlgorithm + PointCompression,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -40,7 +40,7 @@ where
 
 impl<C> Signer<C>
 where
-    C: Curve + CurveAlgorithm + point::Compression,
+    C: Curve + CurveAlgorithm + PointCompression,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -74,7 +74,7 @@ where
 impl<C> From<&Signer<C>> for sec1::EncodedPoint<C>
 where
     Self: Clone,
-    C: Curve + CurveAlgorithm + point::Compression,
+    C: Curve + CurveAlgorithm + PointCompression,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -90,7 +90,7 @@ where
     /// Compute a fixed-sized P-256 ECDSA signature of the given digest
     fn try_sign_digest(&self, digest: D) -> Result<Signature<NistP256>, Error> {
         let sig = self.sign_ecdsa_digest(digest)?;
-        Signature::from_asn1(&sig)
+        Signature::from_der(&sig)
     }
 }
 
@@ -101,7 +101,7 @@ where
     /// Compute a fixed-sized P-384 ECDSA signature of the given digest
     fn try_sign_digest(&self, digest: D) -> Result<Signature<NistP384>, Error> {
         let sig = self.sign_ecdsa_digest(digest)?;
-        Signature::from_asn1(&sig)
+        Signature::from_der(&sig)
     }
 }
 
@@ -114,7 +114,7 @@ where
     fn try_sign_digest(&self, digest: D) -> Result<Signature<Secp256k1>, Error> {
         let mut signature = self
             .sign_ecdsa_digest(digest)
-            .and_then(|sig| Signature::from_asn1(&sig))?;
+            .and_then(|sig| Signature::from_der(&sig))?;
 
         // Low-S normalize per BIP 0062: Dealing with Malleability:
         // <https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki>

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -297,10 +297,10 @@ impl Objects {
 
         match wrap_key.algorithm().wrap().unwrap() {
             wrap::Algorithm::Aes128Ccm => Ok(AesCcmKey::Aes128Ccm(
-                Aes128Ccm::new_varkey(&wrap_key.payload.to_bytes()).unwrap(),
+                Aes128Ccm::new_from_slice(&wrap_key.payload.to_bytes()).unwrap(),
             )),
             wrap::Algorithm::Aes256Ccm => Ok(AesCcmKey::Aes256Ccm(
-                Aes256Ccm::new_varkey(&wrap_key.payload.to_bytes()).unwrap(),
+                Aes256Ccm::new_from_slice(&wrap_key.payload.to_bytes()).unwrap(),
             )),
             unsupported => fail!(
                 ErrorKind::UnsupportedAlgorithm,

--- a/src/mockhsm/object/payload.rs
+++ b/src/mockhsm/object/payload.rs
@@ -78,7 +78,11 @@ impl Payload {
                     Payload::EcdsaSecp256k1(k256::SecretKey::random(&mut OsRng))
                 }
                 asymmetric::Algorithm::Ed25519 => {
-                    Payload::Ed25519Key(ed25519::SecretKey::generate(&mut OsRng))
+                    let mut sk = [0u8; 32];
+                    OsRng.fill_bytes(&mut sk);
+                    Payload::Ed25519Key(
+                        ed25519::SecretKey::from_bytes(&sk).expect("Ed25519 keygen failure"),
+                    )
                 }
                 _ => panic!(
                     "MockHsm doesn't support this asymmetric algorithm: {:?}",

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -67,8 +67,7 @@ impl Debug for Label {
         write!(
             f,
             "{}",
-            self.try_as_str()
-                .unwrap_or_else(|_| INVALID_LABEL_STR_PLACEHOLDER)
+            self.try_as_str().unwrap_or(INVALID_LABEL_STR_PLACEHOLDER)
         )
     }
 }
@@ -78,8 +77,7 @@ impl Display for Label {
         write!(
             f,
             "{}",
-            self.try_as_str()
-                .unwrap_or_else(|_| INVALID_LABEL_STR_PLACEHOLDER)
+            self.try_as_str().unwrap_or(INVALID_LABEL_STR_PLACEHOLDER)
         )
     }
 }

--- a/src/response/code.rs
+++ b/src/response/code.rs
@@ -187,10 +187,7 @@ impl Code {
 
     /// Is this a successful response?
     pub fn is_success(self) -> bool {
-        match self {
-            Code::Success(_) => true,
-            _ => false,
-        }
+        matches!(self, Code::Success(_))
     }
 
     /// Is this an error response?

--- a/src/response/message.rs
+++ b/src/response/message.rs
@@ -138,10 +138,7 @@ impl Message {
 
     /// Did an error occur?
     pub fn is_err(&self) -> bool {
-        match self.code {
-            response::Code::Success(_) => false,
-            _ => true,
-        }
+        !matches!(self.code, response::Code::Success(_))
     }
 
     /// Get the command being responded to
@@ -202,21 +199,15 @@ impl Into<Vec<u8>> for Message {
 /// Do responses with the given code include a session ID?
 fn has_session_id(code: response::Code) -> bool {
     match code {
-        response::Code::Success(cmd_type) => match cmd_type {
-            command::Code::CreateSession | command::Code::SessionMessage => true,
-            _ => false,
-        },
+        response::Code::Success(cmd_type) => matches!(
+            cmd_type,
+            command::Code::CreateSession | command::Code::SessionMessage
+        ),
         _ => false,
     }
 }
 
 /// Do responses with the given code have a Response-MAC (R-MAC) value?
 fn has_rmac(code: response::Code) -> bool {
-    match code {
-        response::Code::Success(cmd_type) => match cmd_type {
-            command::Code::SessionMessage => true,
-            _ => false,
-        },
-        _ => false,
-    }
+    code == response::Code::Success(command::Code::SessionMessage)
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -17,7 +17,7 @@ pub fn serialize<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, Error> {
 /// Deserialize a byte slice into an instance of `T`
 pub fn deserialize<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, Error> {
     let mut deserializer = de::Deserializer::new(Cursor::new(bytes));
-    Ok(serde::Deserialize::deserialize(&mut deserializer)?)
+    serde::Deserialize::deserialize(&mut deserializer)
 }
 
 /// Implement serde serializers/deserializers for array newtypes

--- a/src/session.rs
+++ b/src/session.rs
@@ -291,7 +291,7 @@ impl Drop for Session {
                 .downcast_ref::<String>()
                 .map(AsRef::as_ref)
                 .or_else(|| err.downcast_ref::<&str>().cloned())
-                .unwrap_or_else(|| "unknown cause!");
+                .unwrap_or("unknown cause!");
 
             error!(
                 "session={} panic closing dropped session: {}",

--- a/src/session/securechannel/kdf.rs
+++ b/src/session/securechannel/kdf.rs
@@ -37,7 +37,7 @@ pub fn derive(mac_key: &[u8], derivation_constant: u8, context: &Context, output
     // Derivation context (i.e. challenges concatenated)
     derivation_data[16..].copy_from_slice(context.as_slice());
 
-    let mut mac = Cmac::<Aes128>::new_varkey(mac_key).unwrap();
+    let mut mac = Cmac::<Aes128>::new_from_slice(mac_key).unwrap();
     mac.update(&derivation_data);
     output.copy_from_slice(&mac.finalize().into_bytes().as_slice()[..output_len]);
 }

--- a/tests/command/sign_ecdsa.rs
+++ b/tests/command/sign_ecdsa.rs
@@ -29,7 +29,7 @@ fn generated_nistp256_key_test() {
     let public_key = raw_public_key.ecdsa::<NistP256>().unwrap();
     let test_digest = Sha256::digest(TEST_MESSAGE);
 
-    let signature = Signature::from_asn1(
+    let signature = Signature::from_der(
         &client
             .sign_ecdsa_prehash_raw(TEST_KEY_ID, test_digest.as_slice())
             .unwrap_or_else(|err| panic!("error performing ECDSA signature: {}", err)),

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -5,7 +5,7 @@ use ::ecdsa::{
         consts::U1,
         generic_array::ArrayLength,
         sec1::{UncompressedPointSize, UntaggedPointSize},
-        weierstrass::{point, Curve},
+        weierstrass::{Curve, PointCompression},
     },
     signature::Verifier,
 };
@@ -36,7 +36,7 @@ const TEST_MESSAGE: &[u8] =
 /// Create the signer for this test
 fn create_signer<C>(key_id: object::Id) -> ecdsa::Signer<C>
 where
-    C: Curve + CurveAlgorithm + point::Compression,
+    C: Curve + CurveAlgorithm + PointCompression,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {


### PR DESCRIPTION
Updates the following:
- `aead` v0.4
- `aes` v0.7
- `bitvec` v0.20
- `block-modes` v0.8
- `ccm` v0.4
- `cipher` v0.3
- `cmac` v0.6
- `const-oid` v0.5
- `crypto-mac` v0.11
- `der` v0.3
- `ecdsa` v0.11
- `elliptic-curve` v0.9
- `ff` v0.9
- `group` v0.9
- `hmac` v0.11
- `k256` v0.8
- `p256` v0.8
- `p384` v0.7
- `pbkdf2` v0.8
- `pkcs8` v0.6
- `rand_core` v0.6