### PR TITLE
MSRV 1.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Prerequisites
 
-Minimum Supported Rust Version: Rust **1.46**+.
+Minimum Supported Rust Version: Rust **1.49**+.
 
 On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
 secure communication with the YubiHSM:
@@ -167,7 +167,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [docs-image]: https://docs.rs/yubihsm/badge.svg
 [docs-link]: https://docs.rs/yubihsm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [build-image]: https://github.com/iqlusioninc/yubihsm.rs/workflows/CI/badge.svg?branch=main&event=push
 [build-link]: https://github.com/iqlusioninc/yubihsm.rs/actions?query=workflow:CI
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! This crate requires Rust **1.46** or newer.
-//!
-//! We also recommend building with the following `RUSTFLAGS` on i686/x86_64
-//! architectures for optimal security and performance:
-//!
-//! `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3`
-//!
-//! You can configure your `~/.cargo/config` to always pass these flags:
-//!
-//! ```toml
-//! [build]
-//! rustflags = ["-Ctarget-feature=+aes,+ssse3"]
-//! ```
+//! This crate requires Rust **1.49** or newer.
 //!
 //! # Getting Started
 //!


### PR DESCRIPTION
Updates docs to reflect the new MSRV.

This comes from the `aes` crate among other dependencies.