### PR TITLE
Bump `k256`, `p256`, `p384`, `ecdsa`; MSRV 1.51+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -56,7 +56,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -100,7 +100,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.49.0 # MSRV
+          toolchain: 1.51.0 # MSRV
           components: clippy
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,18 +92,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cpufeatures"
@@ -331,6 +319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,12 +385,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
 dependencies = [
  "const-oid",
- "typenum",
 ]
 
 [[package]]
@@ -406,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba"
+checksum = "1a6cc9051fd9ca5710db0141855d83e666d12f3987359986d52ba4d200343052"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -447,11 +444,11 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.12"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
+checksum = "ade912ac38a947c8bff6d07bcf0ef97327027837963b0452e6f2a9e78b734ebf"
 dependencies = [
- "bitvec",
+ "crypto-bigint",
  "ff",
  "generic-array",
  "group",
@@ -463,11 +460,10 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
- "bitvec",
  "rand_core 0.6.2",
  "subtle",
 ]
@@ -481,12 +477,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -528,9 +518,9 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "group"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
  "rand_core 0.6.2",
@@ -614,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3e8e491ed22bc161583a1c77e42313672c483eba6bd9d7afec0f1131d0b9ce"
+checksum = "e53a50490eff6ca90e3883b0a6ff3bb59153a7807ce21c8ffdbac8c2442cb4c1"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -747,9 +737,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844"
+checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -758,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e3bfd7d8f202c293072de214ad93480b533985bfee4fa4a13cfdd185fab13d"
+checksum = "f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -792,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c2f795bc591cb3384cb64082a578b89207ac92bb89c9d98c1ea2ace7cd8110"
+checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
 dependencies = [
  "der",
  "spki",
@@ -857,12 +847,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -1115,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
 dependencies = [
  "der",
 ]
@@ -1150,12 +1134,6 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
@@ -1426,12 +1404,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yubihsm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ ccm = { version = "0.4", optional = true, features = ["std"] }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 cmac = "0.6"
 digest = { version = "0.9", optional = true, default-features = false }
-ecdsa = { version = "0.11", default-features = false }
+ecdsa = { version = "0.12", default-features = false }
 ed25519 = "1"
 ed25519-dalek = { version = "1", optional = true }
 harp = { version = "0.1", optional = true }
 hmac = { version = "0.11", optional = true }
-k256 = { version = "0.8", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
+k256 = { version = "0.9", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
-p256 = { version = "0.8", default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.7", default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.9", default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.8", default-features = false, features = ["ecdsa"] }
 pbkdf2 = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
@@ -50,7 +50,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 criterion = "0.3"
 ed25519-dalek = "1"
 lazy_static = "1"
-p256 = { version = "0.8", features = ["ecdsa"] }
+p256 = { version = "0.9", features = ["ecdsa"] }
 
 [features]
 default = ["http", "passwords", "setup"]

--- a/README.md
+++ b/README.md
@@ -26,23 +26,9 @@ or endorsed by Yubico (although whoever runs their Twitter account
 *NOTE: Looking for a YubiKey library instead of YubiHSM? Check out
 [yubikey-piv.rs] instead.*
 
-## Prerequisites
+## Minimum Supported Rust Version
 
-Minimum Supported Rust Version: Rust **1.49**+.
-
-On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
-secure communication with the YubiHSM:
-
-```
-RUSTFLAGS=-Ctarget-feature=+aes,+ssse3
-```
-
-You can configure your `~/.cargo/config` to always pass these flags:
-
-```toml
-[build]
-rustflags = ["-Ctarget-feature=+aes,+ssse3"]
-```
+This crate requires Rust **1.51** or newer.
 
 ## Supported Commands
 
@@ -167,7 +153,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [docs-image]: https://docs.rs/yubihsm/badge.svg
 [docs-link]: https://docs.rs/yubihsm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/yubihsm.rs/workflows/CI/badge.svg?branch=main&event=push
 [build-link]: https://github.com/iqlusioninc/yubihsm.rs/actions?query=workflow:CI
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg

--- a/src/asymmetric/public_key.rs
+++ b/src/asymmetric/public_key.rs
@@ -2,10 +2,8 @@
 
 use crate::{asymmetric, ecdsa::algorithm::CurveAlgorithm, ed25519};
 use ::ecdsa::elliptic_curve::{
-    generic_array::{
-        typenum::{Unsigned, U1},
-        ArrayLength, GenericArray,
-    },
+    bigint::Encoding as _,
+    generic_array::{typenum::U1, ArrayLength, GenericArray},
     sec1::{self, UncompressedPointSize, UntaggedPointSize},
     weierstrass::{Curve, PointCompression},
 };
@@ -57,8 +55,7 @@ impl PublicKey {
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {
-        if self.algorithm != C::asymmetric_algorithm()
-            || self.bytes.len() != C::FieldSize::to_usize() * 2
+        if self.algorithm != C::asymmetric_algorithm() || self.bytes.len() != C::UInt::BYTE_SIZE * 2
         {
             return None;
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -669,7 +669,7 @@ impl Client {
         }
 
         Ok(self
-            .send_command(PutOTPAEADKeyCommand {
+            .send_command(PutOtpAeadKeyCommand {
                 params: object::put::Params {
                     id: key_id,
                     label,

--- a/src/connector/usb/device.rs
+++ b/src/connector/usb/device.rs
@@ -188,9 +188,9 @@ impl Device {
         serial_number: SerialNumber,
     ) -> Self {
         Self {
-            serial_number,
-            product_name,
             device,
+            product_name,
+            serial_number,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! This crate requires Rust **1.49** or newer.
+//! This crate requires Rust **1.51** or newer.
 //!
 //! # Getting Started
 //!
@@ -48,6 +48,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+// TODO(tarcieri): address these clippy nits
+#![allow(clippy::from_over_into, clippy::unnecessary_wraps)]
 
 #[macro_use]
 extern crate log;

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -626,7 +626,7 @@ fn sign_ecdsa(state: &State, cmd_data: &[u8]) -> response::Message {
                 let k = p256::Scalar::random(&mut OsRng);
                 let z = p256::Scalar::from_digest(MockDigest256::from(&command));
                 let signature = secret_key
-                    .secret_scalar()
+                    .to_secret_scalar()
                     .try_sign_prehashed(&k, &z)
                     .expect("ECDSA failure!");
 
@@ -636,7 +636,7 @@ fn sign_ecdsa(state: &State, cmd_data: &[u8]) -> response::Message {
                 let k = k256::Scalar::random(&mut OsRng);
                 let z = k256::Scalar::from_digest(MockDigest256::from(&command));
                 let signature = secret_key
-                    .secret_scalar()
+                    .to_secret_scalar()
                     .try_sign_prehashed(&k, &z)
                     .expect("ECDSA failure!");
 

--- a/src/otp/commands/put.rs
+++ b/src/otp/commands/put.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Request parameters for `command::put_otp_aead_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct PutOTPAEADKeyCommand {
+pub(crate) struct PutOtpAeadKeyCommand {
     /// Common parameters to all put object commands
     pub params: object::put::Params,
 
@@ -19,17 +19,17 @@ pub(crate) struct PutOTPAEADKeyCommand {
     pub data: Vec<u8>,
 }
 
-impl Command for PutOTPAEADKeyCommand {
-    type ResponseType = PutOTPAEADKeyResponse;
+impl Command for PutOtpAeadKeyCommand {
+    type ResponseType = PutOtpAeadKeyResponse;
 }
 
 /// Response from `command::put_otp_aead_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct PutOTPAEADKeyResponse {
+pub(crate) struct PutOtpAeadKeyResponse {
     /// ID of the key
     pub key_id: object::Id,
 }
 
-impl Response for PutOTPAEADKeyResponse {
+impl Response for PutOtpAeadKeyResponse {
     const COMMAND_CODE: command::Code = command::Code::PutOtpAead;
 }

--- a/src/response/code.rs
+++ b/src/response/code.rs
@@ -42,7 +42,7 @@ pub enum Code {
     MacMismatch,
 
     /// OK (HSM)
-    DeviceOK,
+    DeviceOk,
 
     /// Invalid command (HSM)
     DeviceInvalidCommand,
@@ -122,7 +122,7 @@ impl Code {
             -8 => Code::CryptogramMismatch,
             -9 => Code::SessionAuthenticationFailed,
             -10 => Code::MacMismatch,
-            -11 => Code::DeviceOK,
+            -11 => Code::DeviceOk,
             -12 => Code::DeviceInvalidCommand,
             -13 => Code::DeviceInvalidData,
             -14 => Code::DeviceInvalidSession,
@@ -160,7 +160,7 @@ impl Code {
             Code::CryptogramMismatch => -8,
             Code::SessionAuthenticationFailed => -9,
             Code::MacMismatch => -10,
-            Code::DeviceOK => -11,
+            Code::DeviceOk => -11,
             Code::DeviceInvalidCommand => -12,
             Code::DeviceInvalidData => -13,
             Code::DeviceInvalidSession => -14,
@@ -214,7 +214,7 @@ impl<'de> Deserialize<'de> for Code {
 
         use de::Error;
         Code::from_u8(value)
-            .or_else(|_| Code::from_u8(Code::DeviceOK.to_u8() - value))
+            .or_else(|_| Code::from_u8(Code::DeviceOk.to_u8() - value))
             .map_err(D::Error::custom)
     }
 }


### PR DESCRIPTION
Bumps the following dependencies:
- `ecdsa` v0.12
- `k256` v0.9
- `p256` v0.9
- `p384` v0.8