### PR TITLE
v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.39.0 (2021-06-09)
+### Changed
+- Bump `rusb` to 0.8.0 ([#170])
+- Bump `aes` to v0.7 ([#183])
+- Bump `aead` to v0.4 ([#183])
+- Bump `ccm` to v0.4 ([#183])
+- Bump `cmac` to v0.6 ([#183])
+- Bump `hmac` to v0.11 ([#183])
+- Bump `pbkdf2` to v0.8 ([#183])
+- Bump `ecdsa` crate to v0.12 ([#207])
+- Bump `k256` crate to v0.9 ([#207])
+- Bump `p256` crate to v0.9 ([#207])
+- Bump `p384` crate to v0.8 ([#207])
+- MSRV 1.51+ ([#207])
+
+[#170]: https://github.com/iqlusioninc/yubihsm.rs/pull/170
+[#183]: https://github.com/iqlusioninc/yubihsm.rs/pull/183
+[#207]: https://github.com/iqlusioninc/yubihsm.rs/pull/207
+
 ## 0.38.0 (2021-02-02)
 ### Changed
 - Bump `tiny_http` dependency to 0.8.0; fixes `RUSTSEC-2020-0031` ([#158])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yubihsm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aes",
  "anomaly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.38.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.39.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.38.0"
+    html_root_url = "https://docs.rs/yubihsm/0.39.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Changed
- Bump `rusb` to 0.8.0 ([#170])
- Bump `aes` to v0.7 ([#183])
- Bump `aead` to v0.4 ([#183])
- Bump `ccm` to v0.4 ([#183])
- Bump `cmac` to v0.6 ([#183])
- Bump `hmac` to v0.11 ([#183])
- Bump `pbkdf2` to v0.8 ([#183])
- Bump `ecdsa` crate to v0.12 ([#207])
- Bump `k256` crate to v0.9 ([#207])
- Bump `p256` crate to v0.9 ([#207])
- Bump `p384` crate to v0.8 ([#207])
- MSRV 1.51+ ([#207])

[#170]: https://github.com/iqlusioninc/yubihsm.rs/pull/170
[#183]: https://github.com/iqlusioninc/yubihsm.rs/pull/183
[#207]: https://github.com/iqlusioninc/yubihsm.rs/pull/207