### PR TITLE
Vendor HTTP client from `harp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,12 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "harp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bf12c625ed5e96f81609ae4377c34e9fa3e4d1fada392404322daeace511ab"
-
-[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,7 +950,6 @@ dependencies = [
  "ecdsa",
  "ed25519",
  "ed25519-dalek",
- "harp",
  "hmac",
  "k256",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ digest = { version = "0.9", optional = true, default-features = false }
 ecdsa = { version = "0.12", default-features = false }
 ed25519 = "1"
 ed25519-dalek = { version = "1", optional = true }
-harp = { version = "0.1", optional = true }
 hmac = { version = "0.11", optional = true }
 k256 = { version = "0.9", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
@@ -55,7 +54,7 @@ p256 = { version = "0.9", features = ["ecdsa"] }
 [features]
 default = ["http", "passwords", "setup"]
 http-server = ["tiny_http"]
-http = ["harp"]
+http = []
 mockhsm = ["ccm", "digest", "ed25519-dalek", "p256/ecdsa", "secp256k1"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 secp256k1 = ["k256"]

--- a/src/connector/error.rs
+++ b/src/connector/error.rs
@@ -4,6 +4,9 @@ use anomaly::{BoxError, Context};
 use std::{fmt, io, num::ParseIntError, str::Utf8Error};
 use thiserror::Error;
 
+#[cfg(feature = "http")]
+use super::http;
+
 #[cfg(feature = "usb")]
 use anomaly::format_err;
 
@@ -67,15 +70,15 @@ impl From<io::Error> for Error {
 }
 
 #[cfg(feature = "http")]
-impl From<harp::Error> for Error {
-    fn from(err: harp::Error) -> Error {
+impl From<http::client::Error> for Error {
+    fn from(err: http::client::Error) -> Error {
         let kind = match err.kind() {
-            harp::ErrorKind::AddrInvalid => ErrorKind::AddrInvalid,
-            harp::ErrorKind::IoError => ErrorKind::IoError,
-            harp::ErrorKind::ParseError | harp::ErrorKind::ResponseError => {
+            http::client::ErrorKind::AddrInvalid => ErrorKind::AddrInvalid,
+            http::client::ErrorKind::IoError => ErrorKind::IoError,
+            http::client::ErrorKind::ParseError | http::client::ErrorKind::ResponseError => {
                 ErrorKind::ResponseError
             }
-            harp::ErrorKind::RequestError => ErrorKind::RequestError,
+            http::client::ErrorKind::RequestError => ErrorKind::RequestError,
         };
 
         kind.context(err).into()

--- a/src/connector/http.rs
+++ b/src/connector/http.rs
@@ -2,6 +2,7 @@
 //!
 //! <https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/>
 
+pub(super) mod client;
 mod config;
 mod connection;
 #[cfg(feature = "http-server")]

--- a/src/connector/http/client.rs
+++ b/src/connector/http/client.rs
@@ -1,0 +1,18 @@
+//! Minimalist HTTP client
+// TODO(tarcieri): replace this with e.g. `ureq`?
+
+#[macro_use]
+pub mod error;
+
+pub mod connection;
+pub mod path;
+pub mod request;
+pub mod response;
+
+pub use self::{connection::*, error::*, path::*};
+
+/// HTTP version.
+pub const HTTP_VERSION: &str = "HTTP/1.1";
+
+/// `User-Agent` string.
+pub const USER_AGENT: &str = concat!("yubihsm.rs ", env!("CARGO_PKG_VERSION"));

--- a/src/connector/http/client/connection.rs
+++ b/src/connector/http/client/connection.rs
@@ -1,0 +1,90 @@
+//! Connections to HTTP servers
+
+use std::{
+    fmt::Write as FmtWrite,
+    io::Write,
+    net::{TcpStream, ToSocketAddrs},
+    ops::DerefMut,
+    string::String,
+    sync::Mutex,
+    time::Duration,
+    vec::Vec,
+};
+
+use super::{error::Error, path::PathBuf, request, response, HTTP_VERSION, USER_AGENT};
+
+/// Default timeout in milliseconds (5 seconds)
+const DEFAULT_TIMEOUT_MS: u64 = 5000;
+
+/// Options when building a `Connection`
+pub struct ConnectionOptions {
+    timeout: Duration,
+}
+
+impl Default for ConnectionOptions {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+        }
+    }
+}
+
+/// HTTP connection to a remote host
+pub struct Connection {
+    /// Host header to send in HTTP requests
+    host: String,
+
+    /// Open TCP socket to remote host
+    socket: Mutex<TcpStream>,
+}
+
+impl Connection {
+    /// Create a new connection to an HTTP server
+    pub fn open(addr: &str, port: u16, opts: &ConnectionOptions) -> Result<Self, Error> {
+        let host = format!("{}:{}", addr, port);
+
+        let socketaddr = &host.to_socket_addrs()?.next().ok_or_else(|| {
+            err!(
+                AddrInvalid,
+                "couldn't resolve DNS for {}",
+                host.split(':').next().unwrap()
+            )
+        })?;
+
+        // TODO: better timeout handling?
+        let socket = TcpStream::connect_timeout(socketaddr, opts.timeout)?;
+        socket.set_read_timeout(Some(opts.timeout))?;
+        socket.set_write_timeout(Some(opts.timeout))?;
+
+        Ok(Self {
+            host,
+            socket: Mutex::new(socket),
+        })
+    }
+
+    /// Make an HTTP POST request to the given path
+    pub fn post<P: Into<PathBuf>>(
+        &self,
+        into_path: P,
+        body: &request::Body,
+    ) -> Result<response::Body, Error> {
+        let path = into_path.into();
+        let mut headers = String::new();
+
+        writeln!(headers, "POST {} {}\r", path, HTTP_VERSION)?;
+        writeln!(headers, "Host: {}\r", self.host)?;
+        writeln!(headers, "User-Agent: {}\r", USER_AGENT)?;
+        writeln!(headers, "Content-Length: {}\r", body.0.len())?;
+        writeln!(headers, "\r")?;
+
+        // Make a Nagle-friendly request by combining headers and body
+        let mut request: Vec<u8> = headers.into();
+        request.extend_from_slice(body.0.as_slice());
+
+        let mut socket = self.socket.lock().unwrap();
+        socket.write_all(&request)?;
+
+        let response_body = response::Reader::new(socket.deref_mut())?.into_body();
+        Ok(response_body)
+    }
+}

--- a/src/connector/http/client/error.rs
+++ b/src/connector/http/client/error.rs
@@ -1,0 +1,149 @@
+//! Error types
+
+#![allow(unused_macros)]
+
+use std::{fmt, num::ParseIntError, str::Utf8Error};
+use std::{
+    io,
+    string::{FromUtf8Error, String, ToString},
+};
+
+/// Error type
+#[derive(Debug)]
+pub struct Error {
+    /// Error context and kind
+    kind: ErrorKind,
+
+    /// Optional description
+    description: Option<String>,
+}
+
+impl Error {
+    /// Create a new error object with an optional error message
+    #[allow(unused_variables)]
+    pub fn new(kind: ErrorKind, description: Option<&str>) -> Self {
+        let mut err = Self::from(kind);
+        err.description = description.map(|desc| desc.into());
+        err
+    }
+
+    /// Obtain the inner `ErrorKind` for this `Error`
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.kind.fmt(f)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            kind,
+            description: None,
+        }
+    }
+}
+
+/// Kinds of errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    /// Invalid address
+    AddrInvalid,
+
+    /// I/O operation failed
+    IoError,
+
+    /// Parsing data failed
+    ParseError,
+
+    /// Request failed
+    RequestError,
+
+    /// Error reading response
+    ResponseError,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self {
+            ErrorKind::AddrInvalid => "address invalid",
+            ErrorKind::IoError => "I/O error",
+            ErrorKind::ParseError => "parse error",
+            ErrorKind::RequestError => "request error",
+            ErrorKind::ResponseError => "error reading response",
+        };
+
+        write!(f, "{}", description)
+    }
+}
+
+/// Create a new error (of a given enum variant) with a formatted message
+macro_rules! err {
+    ($variant:ident, $msg:expr) => {
+        crate::connector::http::client::error::Error::new(
+            crate::connector::http::client::error::ErrorKind::$variant,
+            Some($msg)
+        )
+    };
+    ($variant:ident, $fmt:expr, $($arg:tt)+) => {
+        err!($variant, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Create and return an error with a formatted message
+macro_rules! fail {
+    ($kind:ident, $msg:expr) => {
+        return Err(err!($kind, $msg).into())
+    };
+    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
+        fail!($kind, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Assert a condition is true, returning an error type with a formatted message if not
+macro_rules! ensure {
+    ($condition: expr, $variant:ident, $msg:expr) => {
+        if !($condition) {
+            return Err(err!($variant, $msg).into());
+        }
+    };
+    ($condition: expr, $variant:ident, $fmt:expr, $($arg:tt)+) => {
+        ensure!($variant, $fmt, $($arg)+);
+    };
+}
+
+impl From<ParseIntError> for Error {
+    fn from(err: ParseIntError) -> Self {
+        err!(ParseError, &err.to_string())
+    }
+}
+
+impl From<FromUtf8Error> for Error {
+    fn from(err: FromUtf8Error) -> Self {
+        err!(ParseError, &err.to_string())
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(err: Utf8Error) -> Self {
+        err!(ParseError, &err.to_string())
+    }
+}
+
+impl From<fmt::Error> for Error {
+    fn from(err: fmt::Error) -> Self {
+        err!(RequestError, &err.to_string())
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        err!(IoError, &err.to_string())
+    }
+}

--- a/src/connector/http/client/path.rs
+++ b/src/connector/http/client/path.rs
@@ -1,0 +1,39 @@
+//! Remote paths on HTTP servers
+
+use super::error::Error;
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+/// Paths to HTTP resources (owned buffer)
+// TODO: corresponding borrowed `Path` type
+pub struct PathBuf(String);
+
+impl FromStr for PathBuf {
+    type Err = Error;
+
+    /// Create a path from the given string
+    fn from_str(path: &str) -> Result<Self, Error> {
+        // TODO: validate path
+        Ok(PathBuf(path.to_owned()))
+    }
+}
+
+impl AsRef<str> for PathBuf {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Display for PathBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a> From<&'a str> for PathBuf {
+    fn from(path: &str) -> Self {
+        Self::from_str(path).unwrap()
+    }
+}

--- a/src/connector/http/client/request.rs
+++ b/src/connector/http/client/request.rs
@@ -1,0 +1,18 @@
+//! HTTP request types
+
+/// Request bodies
+#[derive(Debug, Default)]
+pub struct Body(pub(crate) Vec<u8>);
+
+impl Body {
+    /// Create a new `Body` from the given byte slice
+    pub fn new(bytes: &[u8]) -> Body {
+        Body(bytes.into())
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(bytes: Vec<u8>) -> Body {
+        Body(bytes)
+    }
+}

--- a/src/connector/http/client/response.rs
+++ b/src/connector/http/client/response.rs
@@ -1,0 +1,6 @@
+//! HTTP response handling
+
+mod body;
+mod reader;
+
+pub use self::{body::Body, reader::Reader};

--- a/src/connector/http/client/response/body.rs
+++ b/src/connector/http/client/response/body.rs
@@ -1,0 +1,18 @@
+//! Response body types.
+
+/// Response body
+#[derive(Debug)]
+pub struct Body(pub(super) Vec<u8>);
+
+impl Body {
+    /// Buffer the response body into a `Vec<u8>` and return it
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Body> for Vec<u8> {
+    fn from(body: Body) -> Vec<u8> {
+        body.into_vec()
+    }
+}

--- a/src/connector/http/client/response/reader.rs
+++ b/src/connector/http/client/response/reader.rs
@@ -1,0 +1,153 @@
+//! Read HTTP responses from an `io::Read`
+
+#![allow(clippy::manual_strip)]
+
+use super::Body;
+use crate::connector::http::client::Error;
+use std::{io::Read, str, vec::Vec};
+
+const TRANSFER_ENCODING_HEADER: &str = "Transfer-Encoding: ";
+const HEADER_DELIMITER: &[u8] = b"\r\n\r\n";
+const HTTP_SUCCESS_STATUS: &str = "HTTP/1.1 200 OK";
+const CONTENT_LENGTH_HEADER: &str = "Content-Length: ";
+
+/// Maximum response size we can parse.
+// TODO: we shouldn't have a max, or at least one this small
+const MAX_RESPONSE_SIZE: usize = 65536;
+
+/// Read HTTP responses from the server
+pub struct Reader {
+    /// Internal buffer
+    buffer: Vec<u8>,
+
+    /// Position within the response
+    pos: usize,
+
+    /// Offset into the body we've ready so far
+    body_offset: Option<usize>,
+
+    /// Total length of the response content
+    content_length: usize,
+}
+
+impl Reader {
+    /// Create a new `response::Reader` that consumes a response body from a socket
+    #[allow(clippy::new_ret_no_self)]
+    pub(crate) fn new(readable: &mut dyn Read) -> Result<Self, Error> {
+        // TODO: better buffering
+        let mut buffer = Self {
+            buffer: vec![0u8; MAX_RESPONSE_SIZE],
+            pos: 0,
+            body_offset: None,
+            content_length: 0,
+        };
+
+        buffer.read_headers(readable)?;
+        buffer.read_body(readable)?;
+
+        Ok(buffer)
+    }
+
+    /// Convert this `response::Reader` into a `response::Body`
+    pub(crate) fn into_body(self) -> Body {
+        let body_offset = self
+            .body_offset
+            .expect("we should've already read the body");
+
+        Body(Vec::from(&self.buffer[body_offset..self.pos]))
+    }
+
+    /// Fill the internal buffer with data from the socket
+    fn fill_buffer(&mut self, readable: &mut dyn Read) -> Result<usize, Error> {
+        let nbytes = readable.read(self.buffer.as_mut())?;
+        self.pos += nbytes;
+        Ok(nbytes)
+    }
+
+    /// Read the response headers
+    fn read_headers(&mut self, readable: &mut dyn Read) -> Result<(), Error> {
+        assert!(self.body_offset.is_none(), "already read headers!");
+
+        loop {
+            self.fill_buffer(readable)?;
+
+            // Scan for the header delimiter
+            // TODO: real parser
+            let mut offset = 0;
+            while self.buffer[offset..].len() > HEADER_DELIMITER.len() {
+                if self.buffer[offset..].starts_with(HEADER_DELIMITER) {
+                    self.body_offset = Some(offset + HEADER_DELIMITER.len());
+                    break;
+                } else {
+                    offset += 1;
+                }
+            }
+
+            if self.body_offset.is_some() {
+                break;
+            } else if self.pos + 1 >= MAX_RESPONSE_SIZE {
+                fail!(
+                    ResponseError,
+                    "exceeded {}-byte response limit reading headers",
+                    MAX_RESPONSE_SIZE
+                );
+            }
+        }
+
+        self.parse_headers()
+    }
+
+    /// Parse the response headers
+    fn parse_headers(&mut self) -> Result<(), Error> {
+        let body_offset = self.body_offset.unwrap();
+        let header_str = str::from_utf8(&self.buffer[..body_offset])?;
+        let mut header_iter = header_str.split("\r\n");
+
+        match header_iter.next() {
+            Some(HTTP_SUCCESS_STATUS) => (),
+            Some(status) => fail!(
+                ResponseError,
+                "unexpected HTTP response status: \"{}\"",
+                status
+            ),
+            None => fail!(ResponseError, "HTTP response status line missing!"),
+        }
+
+        for header in header_iter {
+            if header.starts_with(CONTENT_LENGTH_HEADER) {
+                let content_length: usize = header[CONTENT_LENGTH_HEADER.len()..].parse()?;
+
+                if MAX_RESPONSE_SIZE - body_offset < content_length {
+                    fail!(
+                        ResponseError,
+                        "response body length too large for buffer ({} bytes)",
+                        content_length
+                    );
+                }
+
+                self.content_length = content_length;
+            } else if header.starts_with(TRANSFER_ENCODING_HEADER) {
+                let transfer_encoding = &header[TRANSFER_ENCODING_HEADER.len()..];
+                fail!(
+                    ResponseError,
+                    "connection sent unsupported transfer encoding: {}",
+                    transfer_encoding
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read the response body into the internal buffer
+    fn read_body(&mut self, readable: &mut dyn Read) -> Result<(), Error> {
+        let body_end =
+            self.content_length + self.body_offset.expect("not ready to read the body yet");
+
+        while self.pos < body_end {
+            self.fill_buffer(readable)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/connector/http/connection.rs
+++ b/src/connector/http/connection.rs
@@ -1,12 +1,8 @@
 //! Persistent HTTP connection to `yubihsm-connector`
 
-use super::config::HttpConfig;
+use super::{client, config::HttpConfig};
 use crate::connector::{self, Connection};
 use uuid::Uuid;
-
-// TODO: send user agent string
-// User-Agent string to supply
-// pub const USER_AGENT: &str = concat!("yubihsm.rs ", env!("CARGO_PKG_VERSION"));
 
 /// Connection to YubiHSM via HTTP requests to `yubihsm-connector`.
 ///
@@ -19,13 +15,13 @@ use uuid::Uuid;
 /// <https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/>
 pub struct HttpConnection {
     /// HTTP connection
-    connection: harp::Connection,
+    connection: client::Connection,
 }
 
 impl HttpConnection {
     /// Open a connection to a `yubihsm-connector` service
     pub(crate) fn open(config: &HttpConfig) -> Result<Self, connector::Error> {
-        let connection = harp::Connection::open(&config.addr, config.port, &Default::default())?;
+        let connection = client::Connection::open(&config.addr, config.port, &Default::default())?;
 
         Ok(HttpConnection { connection })
     }
@@ -40,7 +36,7 @@ impl HttpConnection {
         // TODO: send UUID as `X-Request-ID` header, zero copy body creation
         Ok(self
             .connection
-            .post(path, &harp::request::Body::new(body))?
+            .post(path, &client::request::Body::new(body))?
             .into_vec())
     }
 }


### PR DESCRIPTION
The `harp` crate provided a minimalist HTTP client that does what the YubiHSM connector client needs, and nothing more.

yubihsm.rs is currently the only user of `harp`, so it makes sense to just vendor it into this crate so it doesn't need to be maintained separately and refactoring can apply to both. (As it were, `harp` was extracted from this crate with the goals of making it more general, but that never worked out. C'est la vie)

Long term it would probably make sense to switch to a minimalist HTTP client like `ureq`.