### PR TITLE
Remove `anomaly` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,15 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anomaly"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "ascii"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,21 +35,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bitflags"
@@ -367,12 +328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
 name = "group"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,22 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,15 +440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -653,12 +583,6 @@ dependencies = [
  "libc",
  "libusb1-sys",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "ryu"
@@ -940,7 +864,6 @@ name = "yubihsm"
 version = "0.39.0"
 dependencies = [
  "aes",
- "anomaly",
  "bitflags",
  "block-modes",
  "ccm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rust-version = "1.56"
 
 [dependencies]
 aes = "0.7"
-anomaly = "0.2"
 bitflags = "1"
 block-modes = "0.8"
 ccm = { version = "0.4", optional = true, features = ["std"] }

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -5,7 +5,6 @@ mod error;
 pub use self::error::{Error, ErrorKind};
 
 use crate::{asymmetric, authentication, ecdh, ecdsa, hmac, opaque, otp, rsa, template, wrap};
-use anomaly::fail;
 
 /// Cryptographic algorithm types supported by the `YubiHSM 2`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/algorithm/error.rs
+++ b/src/algorithm/error.rs
@@ -1,6 +1,6 @@
 //! Algorithm errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// `Algorithm`-related errors

--- a/src/asymmetric/algorithm.rs
+++ b/src/asymmetric/algorithm.rs
@@ -1,7 +1,6 @@
 //! Asymmetric algorithm support
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Asymmetric algorithms (RSA or ECC)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -6,7 +6,6 @@ mod error;
 pub use self::error::{Error, ErrorKind};
 
 use crate::command;
-use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 

--- a/src/audit/error.rs
+++ b/src/audit/error.rs
@@ -1,6 +1,6 @@
 //! Audit errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Audit-related errors

--- a/src/authentication/algorithm.rs
+++ b/src/authentication/algorithm.rs
@@ -1,7 +1,6 @@
 //! Authentication algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Valid algorithms for auth keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/authentication/error.rs
+++ b/src/authentication/error.rs
@@ -1,6 +1,6 @@
 //! Authentication errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Authentication errors

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -1,16 +1,18 @@
 //! `YubiHSM 2` authentication keys (2 * AES-128 symmetric PSK) from which session keys are derived
 
 use super::{Error, ErrorKind};
-use anomaly::ensure;
-#[cfg(feature = "hmac")]
-use hmac::Hmac;
-#[cfg(feature = "pbkdf2")]
-use pbkdf2::pbkdf2;
 use rand_core::{OsRng, RngCore};
-#[cfg(feature = "sha2")]
-use sha2::Sha256;
 use std::fmt::{self, Debug};
 use zeroize::Zeroize;
+
+#[cfg(feature = "hmac")]
+use hmac::Hmac;
+
+#[cfg(feature = "pbkdf2")]
+use pbkdf2::pbkdf2;
+
+#[cfg(feature = "sha2")]
+use sha2::Sha256;
 
 /// Auth keys are 2 * AES-128 keys
 pub const SIZE: usize = 32;

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,7 @@
 mod error;
 
 pub use self::error::{Error, ErrorKind};
+
 use crate::{
     asymmetric::{self, commands::*, PublicKey},
     attestation::{self, commands::*},
@@ -33,7 +34,6 @@ use crate::{
     uuid,
     wrap::{self, commands::*},
 };
-use anomaly::{ensure, fail, format_err};
 use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,7 +1,10 @@
 //! YubiHSM client errors
 
-use crate::{connector, device, serialization, session};
-use anomaly::{BoxError, Context};
+use crate::{
+    connector, device,
+    error::{BoxError, Context},
+    serialization, session,
+};
 use std::io;
 use thiserror::Error;
 

--- a/src/command/code.rs
+++ b/src/command/code.rs
@@ -1,7 +1,6 @@
 //! YubiHSM2 command codes
 
 use super::{Error, ErrorKind};
-use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 
 /// Command IDs for `YubiHSM 2` operations

--- a/src/command/error.rs
+++ b/src/command/error.rs
@@ -1,6 +1,6 @@
 //! Command-related errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Command-related errors

--- a/src/command/message.rs
+++ b/src/command/message.rs
@@ -18,9 +18,6 @@ use crate::{
     },
     uuid::{self, Uuid},
 };
-use anomaly::ensure;
-#[cfg(any(feature = "http-server", feature = "mockhsm"))]
-use anomaly::{fail, format_err};
 
 /// A command sent from the host to the `YubiHSM 2`. May or may not be
 /// authenticated using SCP03's chained/evolving MAC protocol.

--- a/src/connector/error.rs
+++ b/src/connector/error.rs
@@ -1,14 +1,11 @@
 //! Error types for `yubihsm-connector`
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use std::{fmt, io, num::ParseIntError, str::Utf8Error};
 use thiserror::Error;
 
 #[cfg(feature = "http")]
 use super::http;
-
-#[cfg(feature = "usb")]
-use anomaly::format_err;
 
 /// `yubihsm-connector` related errors
 pub type Error = crate::Error<ErrorKind>;

--- a/src/connector/http/server.rs
+++ b/src/connector/http/server.rs
@@ -18,7 +18,6 @@ use crate::{
     },
     uuid,
 };
-use anomaly::format_err;
 use std::{io, process, time::Instant};
 use tiny_http as http;
 

--- a/src/connector/usb/connection.rs
+++ b/src/connector/usb/connection.rs
@@ -7,7 +7,6 @@ use crate::{
     command::MAX_MSG_SIZE,
     connector::{self, Connection, ErrorKind::UsbError, Message},
 };
-use anomaly::fail;
 use std::sync::Mutex;
 use uuid::Uuid;
 

--- a/src/connector/usb/device.rs
+++ b/src/connector/usb/device.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     device::SerialNumber,
 };
-use anomaly::{fail, format_err};
 use std::{
     fmt::{self, Debug},
     slice::Iter,

--- a/src/connector/usb/macros.rs
+++ b/src/connector/usb/macros.rs
@@ -23,7 +23,7 @@ macro_rules! usb_debug {
 macro_rules! usb_err {
     ($device:expr, $msg:expr) => {
         {
-            use anomaly::format_err;
+
             format_err!(
                 UsbError,
                 "USB(bus={},addr={}): {}",
@@ -35,7 +35,7 @@ macro_rules! usb_err {
     };
     ($device:expr, $fmt:expr, $($arg:tt)+) => {
         {
-            use anomaly::format_err;
+
             format_err!(
                 UsbError,
                 concat!("USB(bus={},addr={}): ", $fmt),

--- a/src/device/error.rs
+++ b/src/device/error.rs
@@ -1,7 +1,7 @@
 //! Error types which map directly to the YubiHSM2's error codes
 
+use crate::error::{BoxError, Context};
 use crate::response;
-use anomaly::{BoxError, Context};
 use thiserror::Error;
 
 /// Errors which originate in the HSM

--- a/src/device/serial.rs
+++ b/src/device/serial.rs
@@ -1,7 +1,6 @@
 //! YubiHSM 2 device serial numbers
 
 use super::error::{Error, ErrorKind};
-use anomaly::{fail, format_err};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display},

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -6,7 +6,6 @@ mod error;
 
 pub use self::error::{Error, ErrorKind};
 
-use anomaly::fail;
 use bitflags::bitflags;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -1,6 +1,6 @@
 //! Domain errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Audit-related errors

--- a/src/ecdh/algorithm.rs
+++ b/src/ecdh/algorithm.rs
@@ -1,7 +1,6 @@
 //! Key exchange algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Key exchange algorithms (a.k.a. Diffie-Hellman)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/ecdsa/algorithm.rs
+++ b/src/ecdsa/algorithm.rs
@@ -2,7 +2,6 @@
 
 use super::{NistP256, NistP384};
 use crate::{algorithm, asymmetric};
-use anomaly::fail;
 
 #[cfg(feature = "secp256k1")]
 use super::Secp256k1;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,163 @@
 //! Error types
 
-use anomaly::{BoxError, Context};
 use std::{
     fmt::{self, Debug, Display},
     ops::Deref,
 };
+
+/// Create a new error (of a given kind) with a formatted [`Message`]
+/// as its source.
+///
+/// If additional parameters are given, the second is used as a format string,
+/// e.g. `format_err!(kind, "something went wrong: {}", &wrongness)`.
+macro_rules! format_err {
+    ($kind:expr, $msg:expr) => {
+        $kind.context($crate::error::Message::new($msg))
+    };
+    ($kind:expr, $fmt:expr, $($arg:tt)+) => {
+        format_err!($kind, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Create and return an error with a formatted [`Message`].
+macro_rules! fail {
+    ($kind:expr, $msg:expr) => {
+        return Err(format_err!($kind, $msg).into())
+    };
+    ($kind:expr, $fmt:expr, $($arg:tt)+) => {
+        fail!($kind, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Ensure a condition holds, returning an error if it doesn't (ala `assert`)
+macro_rules! ensure {
+    ($cond:expr, $kind:expr, $msg:expr) => {
+        if !($cond) {
+            return Err(format_err!($kind, $msg).into())
+        }
+    };
+    ($cond:expr, $kind:expr, $fmt:expr, $($arg:tt)+) => {
+        ensure!($cond, $kind, format!($fmt, $($arg)+))
+    };
+}
+
+/// Box containing a thread-safe + `'static` error suitable for use as a
+/// as an `std::error::Error::source`.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Error context: stores an error source (as a [`BoxError`]) and backtrace
+/// along with an error `Kind`.
+#[derive(Debug)]
+pub struct Context<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    /// Kind of error
+    kind: Kind,
+
+    /// Source of the error
+    source: Option<BoxError>,
+
+    /// Backtrace where error occurred
+    #[cfg(feature = "backtrace")]
+    backtrace: Option<Backtrace>,
+}
+
+impl<Kind> Context<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    /// Create a new error context
+    pub fn new(kind: Kind, source: Option<BoxError>) -> Self {
+        Context {
+            kind,
+            source,
+            #[cfg(feature = "backtrace")]
+            backtrace: Some(Backtrace::new()),
+        }
+    }
+
+    /// Get the kind of error
+    pub fn kind(&self) -> &Kind {
+        &self.kind
+    }
+
+    /// Get the backtrace associated with this error (if available)
+    #[cfg(feature = "backtrace")]
+    pub fn backtrace(&self) -> Option<&Backtrace> {
+        self.backtrace.as_ref()
+    }
+}
+
+impl<Kind> Display for Context<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.kind)?;
+
+        if let Some(ref source) = self.source {
+            write!(f, ": {}", source)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<Kind> From<Kind> for Context<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn from(kind: Kind) -> Context<Kind> {
+        Self::new(kind, None)
+    }
+}
+
+impl<Kind> std::error::Error for Context<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
+/// Error message type: provide additional context with a string.
+///
+/// This is generally discouraged whenever possible as it will complicate
+/// future I18n support. However, it can be useful for things with
+/// language-independent string representations for error contexts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Message(String);
+
+impl Message {
+    /// Create a new error message
+    pub fn new(msg: impl ToString) -> Self {
+        Message(msg.to_string())
+    }
+}
+
+impl AsRef<str> for Message {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl std::error::Error for Message {}
+
+impl From<String> for Message {
+    fn from(string: String) -> Message {
+        Message(string)
+    }
+}
 
 /// Error type
 #[derive(Debug)]

--- a/src/hmac/algorithm.rs
+++ b/src/hmac/algorithm.rs
@@ -1,7 +1,6 @@
 //! HMAC algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Valid algorithms for HMAC keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/mockhsm/connection.rs
+++ b/src/mockhsm/connection.rs
@@ -1,14 +1,12 @@
 //! Mock connection to the MockHSM
 
-use anomaly::{fail, format_err};
-use std::sync::{Arc, Mutex};
-use uuid::Uuid;
-
 use super::{command, state::State, MockHsm};
 use crate::{
     command::Code,
     connector::{self, Connection, ErrorKind::ConnectionFailed, Message},
 };
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
 /// A mocked connection to the MockHsm
 pub struct MockConnection(Arc<Mutex<State>>);

--- a/src/mockhsm/error.rs
+++ b/src/mockhsm/error.rs
@@ -1,6 +1,6 @@
 //! MockHSM errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// `MockHsm`-related errors

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -9,7 +9,6 @@ use crate::{
     wrap, Algorithm, Capability, Domain,
 };
 use aes::cipher::consts::{U13, U8};
-use anomaly::{fail, format_err};
 use ccm::aead::{AeadInPlace, NewAead};
 use std::collections::{btree_map::Iter as MapIter, BTreeMap as Map};
 

--- a/src/mockhsm/state.rs
+++ b/src/mockhsm/state.rs
@@ -10,7 +10,6 @@ use crate::{
         securechannel::{Challenge, SecureChannel},
     },
 };
-use anomaly::format_err;
 use std::collections::BTreeMap;
 
 /// Mutable interior state of the `MockHsm`

--- a/src/object/error.rs
+++ b/src/object/error.rs
@@ -1,6 +1,6 @@
 //! Object errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// `Object`-related errors

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -4,13 +4,10 @@ use crate::{algorithm::Algorithm, capability::Capability, client, domain::Domain
 use std::io::Write;
 
 #[cfg(feature = "mockhsm")]
-use crate::client::ErrorKind::ProtocolError;
-#[cfg(feature = "mockhsm")]
-use crate::object::LABEL_SIZE;
-#[cfg(feature = "mockhsm")]
-use anomaly::{fail, format_err};
-#[cfg(feature = "mockhsm")]
-use std::io::Read;
+use {
+    crate::{client::ErrorKind::ProtocolError, object::LABEL_SIZE},
+    std::io::Read,
+};
 
 /// Filters to apply when listing objects
 pub enum Filter {

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -1,7 +1,6 @@
 //! Object labels: descriptions of objects
 
 use super::{Error, ErrorKind};
-use anomaly::fail;
 use std::{
     fmt::{self, Debug, Display},
     ops::{Deref, DerefMut},

--- a/src/object/origins.rs
+++ b/src/object/origins.rs
@@ -1,7 +1,6 @@
 //! Information about where a key originates (i.e. where it was generated)
 
 use super::{Error, ErrorKind};
-use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -1,7 +1,6 @@
 //! Types of objects
 
 use super::{Error, ErrorKind};
-use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 

--- a/src/opaque/algorithm.rs
+++ b/src/opaque/algorithm.rs
@@ -1,7 +1,6 @@
 //! Pseudo-algorithms for opaque data
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Valid algorithms for opaque data
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/otp/algorithm.rs
+++ b/src/otp/algorithm.rs
@@ -1,7 +1,6 @@
 //! Yubico OTP algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Valid algorithms for Yubico OTP (AES-based one time password) keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/response/code.rs
+++ b/src/response/code.rs
@@ -2,7 +2,6 @@
 
 use super::{Error, ErrorKind};
 use crate::command;
-use anomaly::{fail, format_err};
 use serde::{de, ser, Deserialize, Serialize};
 
 /// Codes associated with HSM responses

--- a/src/response/error.rs
+++ b/src/response/error.rs
@@ -1,6 +1,6 @@
 //! Response errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Response-related errors

--- a/src/response/message.rs
+++ b/src/response/message.rs
@@ -12,7 +12,6 @@ use crate::{
         ErrorKind::ProtocolError,
     },
 };
-use anomaly::{fail, format_err};
 
 #[cfg(feature = "mockhsm")]
 use crate::device;

--- a/src/rsa/algorithm.rs
+++ b/src/rsa/algorithm.rs
@@ -2,7 +2,6 @@
 
 use super::{oaep, pkcs1, pss};
 use crate::algorithm;
-use anomaly::fail;
 
 /// RSA algorithms (signing and encryption)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/mgf.rs
+++ b/src/rsa/mgf.rs
@@ -1,7 +1,6 @@
 //! Mask generating functions for use with RSASSA-PSS signatures
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Mask generating functions for RSASSA-PSS
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/oaep/algorithm.rs
+++ b/src/rsa/oaep/algorithm.rs
@@ -1,7 +1,6 @@
 //! RSA OAEP algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// RSA Optimal Asymmetric Encryption Padding (OAEP) algorithms
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/pkcs1/algorithm.rs
+++ b/src/rsa/pkcs1/algorithm.rs
@@ -1,7 +1,6 @@
 //! RSA PKCS#1v1.5 algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// RSA PKCS#1v1.5: legacy algorithms
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/pss/algorithm.rs
+++ b/src/rsa/pss/algorithm.rs
@@ -1,7 +1,6 @@
 //! RSASSA-PSS algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// RSASSA-PSS algorithms
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/serialization/error.rs
+++ b/src/serialization/error.rs
@@ -1,6 +1,6 @@
 //! Serialization errors
 
-use anomaly::{format_err, BoxError, Context};
+use crate::error::{BoxError, Context};
 use serde::{de, ser};
 use std::{fmt, io};
 use thiserror::Error;

--- a/src/session.rs
+++ b/src/session.rs
@@ -28,7 +28,6 @@ use crate::{
     device, response,
     serialization::deserialize,
 };
-use anomaly::{ensure, fail, format_err};
 use std::{
     panic::{self, AssertUnwindSafe},
     time::{Duration, Instant},

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -1,7 +1,7 @@
 //! Session error types
 
+use crate::error::{BoxError, Context};
 use crate::{connector, device, serialization};
-use anomaly::{BoxError, Context};
 use thiserror::Error;
 
 /// Session errors

--- a/src/session/id.rs
+++ b/src/session/id.rs
@@ -1,7 +1,6 @@
 //! Session IDs: the YubiHSM2 supports up to 16 concurrent sessions.
 
 use super::{Error, ErrorKind::ProtocolError};
-use anomaly::fail;
 use std::fmt::{self, Display};
 
 /// Maximum session identifier

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -43,7 +43,7 @@ use aes::{
     cipher::{consts::U16, generic_array::GenericArray, BlockEncrypt, NewBlockCipher},
     Aes128,
 };
-use anomaly::{fail, format_err};
+
 use block_modes::{block_padding::Iso7816, BlockMode, Cbc};
 use cmac::crypto_mac::NewMac;
 use cmac::{crypto_mac::Mac as CryptoMac, Cmac};
@@ -633,10 +633,8 @@ mod tests {
 
     fn create_channel_pair() -> (SecureChannel, SecureChannel) {
         let authentication_key = authentication::Key::derive_from_password(PASSWORD);
-
         let host_challenge = Challenge::from_slice(HOST_CHALLENGE);
         let card_challenge = Challenge::from_slice(CARD_CHALLENGE);
-
         let session_id = session::Id::from_u8(0).unwrap();
 
         // Create channels
@@ -646,6 +644,7 @@ mod tests {
             host_challenge,
             card_challenge,
         );
+
         let mut card_channel = SecureChannel::new(
             session_id,
             &authentication_key,

--- a/src/session/securechannel/mac.rs
+++ b/src/session/securechannel/mac.rs
@@ -7,7 +7,6 @@
 //! lower (~2^32 messages).
 
 use crate::session;
-use anomaly::fail;
 use cmac::crypto_mac::generic_array::{typenum::U16, GenericArray};
 use std::fmt;
 use subtle::{Choice, ConstantTimeEq};

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -16,7 +16,6 @@ use crate::{
     authentication::{self, Credentials, DEFAULT_AUTHENTICATION_KEY_ID},
     object, Capability, Client, Connector, Domain,
 };
-use anomaly::format_err;
 
 /// Label to place on the temporary setup auth key ID
 const SETUP_KEY_LABEL: &str = "yubihsm.rs temporary setup key";

--- a/src/setup/error.rs
+++ b/src/setup/error.rs
@@ -1,6 +1,6 @@
 //! YubiHSM setup errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Setup-related errors

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -9,7 +9,6 @@ use crate::{
     uuid::{self, Uuid},
     Capability, Client, Domain,
 };
-use anomaly::format_err;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{env, str::FromStr};

--- a/src/setup/role.rs
+++ b/src/setup/role.rs
@@ -3,7 +3,6 @@
 use super::{Error, ErrorKind};
 use crate::Client;
 pub use crate::{object, Capability, Credentials, Domain};
-use anomaly::format_err;
 
 /// Roles represent accounts on the device with specific permissions
 #[derive(Clone, Debug)]

--- a/src/template/algorithm.rs
+++ b/src/template/algorithm.rs
@@ -1,7 +1,6 @@
 //! SSH certificate templates
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Template algorithms (for SSH)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/wrap/algorithm.rs
+++ b/src/wrap/algorithm.rs
@@ -1,7 +1,6 @@
 //! Wrap algorithms
 
 use crate::algorithm;
-use anomaly::fail;
 
 /// Valid algorithms for "wrap" (symmetric encryption/key wrapping) keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/wrap/error.rs
+++ b/src/wrap/error.rs
@@ -1,6 +1,6 @@
 //! Key wrapping errors
 
-use anomaly::{BoxError, Context};
+use crate::error::{BoxError, Context};
 use thiserror::Error;
 
 /// Wrap-related errors

--- a/src/wrap/key.rs
+++ b/src/wrap/key.rs
@@ -7,7 +7,6 @@
 // TODO(tarcieri): use this for `yubihsm::client::put_wrap_key` in general?
 
 use crate::{client, device, object, wrap, Capability, Client, Domain};
-use anomaly::fail;
 use rand_core::{OsRng, RngCore};
 use std::fmt::{self, Debug};
 use zeroize::{Zeroize, Zeroizing};

--- a/src/wrap/message.rs
+++ b/src/wrap/message.rs
@@ -2,7 +2,6 @@
 
 use super::nonce::{self, Nonce};
 use super::{Error, ErrorKind};
-use anomaly::fail;
 use serde::{Deserialize, Serialize};
 
 /// Wrap wessage (encrypted HSM object or arbitrary data) encrypted under a wrap key


### PR DESCRIPTION
The original goal of `anomaly` was to consolidate copy/pasted error-handling boilerplate across the various iqlusion crates/apps into a single crate which provided it instead.

In the time since, everything that was using `anomaly` has moved onto newly emerged options for error handling like `eyre`.

While it would be good to eventually migrate this crate to `eyre` as well, that's a fairly large undertaking. This is a first incremental step towards that, as removing the `anomaly` dependency allows a more piecemeal transition.

This commits vendors the parts of `anomaly` that this crate is using into the `error.rs` file, with the goal of retiring `anomaly` entirely.