### PR TITLE
Replace `chrono` with the `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,8 +107,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "serde",
- "time",
  "winapi",
 ]
 
@@ -729,12 +727,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "libc",
- "winapi",
+ "serde",
 ]
 
 [[package]]
@@ -867,7 +865,6 @@ dependencies = [
  "bitflags",
  "block-modes",
  "ccm",
- "chrono",
  "cmac",
  "digest",
  "ecdsa",
@@ -888,6 +885,7 @@ dependencies = [
  "signature",
  "subtle",
  "thiserror",
+ "time",
  "tiny_http",
  "uuid",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ aes = "0.7"
 bitflags = "1"
 block-modes = "0.8"
 ccm = { version = "0.4", optional = true, features = ["std"] }
-chrono = { version = "0.4", features = ["serde"], optional = true }
 cmac = "0.6"
 digest = { version = "0.9", optional = true, default-features = false }
 ecdsa = { version = "0.12", default-features = false }
@@ -41,6 +40,7 @@ sha2 = { version = "0.9", optional = true }
 signature = { version = "1.3.2", features = ["derive-preview"] }
 subtle = "2"
 thiserror = "1"
+time = { version = "0.3", features = ["serde"] }
 tiny_http = { version = "0.9", optional = true }
 uuid = { version = "0.8", default-features = false }
 zeroize = { version = "1", features = ["zeroize_derive"] }
@@ -57,7 +57,7 @@ http = []
 mockhsm = ["ccm", "digest", "ed25519-dalek", "p256/ecdsa", "secp256k1"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 secp256k1 = ["k256"]
-setup = ["chrono", "passwords", "serde_json", "uuid/serde"]
+setup = ["passwords", "serde_json", "uuid/serde"]
 untested = ["sha2"]
 usb = ["rusb"]
 

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -9,9 +9,9 @@ use crate::{
     uuid::{self, Uuid},
     Capability, Client, Domain,
 };
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{env, str::FromStr};
+use time::OffsetDateTime as DateTime;
 
 /// Label string for the provisioning report object
 pub const REPORT_OBJECT_LABEL: &str = "yubihsm.rs setup report";
@@ -45,7 +45,7 @@ pub struct Report {
     pub username: Option<String>,
 
     /// Date the device was provisioned
-    pub date: DateTime<Utc>,
+    pub date: DateTime,
 
     /// Software that performed the provisioning
     pub software: String,
@@ -61,7 +61,7 @@ impl Report {
             device_serial_number: serial_number.to_string(),
             username: env::var("LOGNAME").ok(),
             hostname: env::var("HOSTNAME").ok(),
-            date: Utc::now(),
+            date: DateTime::now_utc(),
             software: format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
         }
     }


### PR DESCRIPTION
The `time` crate provides all of the features we need and is more actively maintained.