### PR TITLE
Replace `lazy_static` with `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,12 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +433,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -872,8 +872,8 @@ dependencies = [
  "ed25519-dalek",
  "hmac",
  "k256",
- "lazy_static",
  "log",
+ "once_cell",
  "p256",
  "p384",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ed25519-dalek = "1"
-lazy_static = "1"
+once_cell = "1"
 p256 = { version = "0.9", features = ["ecdsa"] }
 
 [features]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests (using live YubiHSM 2 or MockHsm)
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::sync::{Mutex, MutexGuard};
 use yubihsm::{asymmetric, device, object, Capability, Client, Connector, Domain};
 
@@ -40,14 +40,11 @@ const TEST_MESSAGE: &[u8] = b"The YubiHSM 2 is a simple, affordable, and secure 
 /// Size of a NIST P-256 public key
 pub const EC_P256_PUBLIC_KEY_SIZE: usize = 64;
 
-lazy_static! {
-    static ref HSM_CONNECTOR: Connector = create_hsm_connector();
-}
+static HSM_CONNECTOR: Lazy<Connector> = Lazy::new(create_hsm_connector);
 
-lazy_static! {
-    static ref HSM_CLIENT: Mutex<Client> =
-        Mutex::new(Client::open(HSM_CONNECTOR.clone(), Default::default(), true).unwrap());
-}
+static HSM_CLIENT: Lazy<Mutex<Client>> = Lazy::new(|| {
+    Mutex::new(Client::open(HSM_CONNECTOR.clone(), Default::default(), true).unwrap())
+});
 
 /// Create a `yubihsm::Client` to run the test suite against
 pub fn get_hsm_client() -> MutexGuard<'static, Client> {


### PR DESCRIPTION
`once_cell` avoids the use of macros, and will hopefully eventually be merged into the standard library.