### PR TITLE
Add suport for decrypt_oaep command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,6 @@ dependencies = [
  "p256",
  "p384",
  "pbkdf2",
- "rand 0.8.4",
  "rand_core 0.6.3",
  "rsa",
  "rusb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,21 @@ checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64ct"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 
 [[package]]
 name = "bitflags"
@@ -211,6 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
 ]
 
 [[package]]
@@ -251,7 +264,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2",
  "zeroize",
@@ -383,10 +396,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libusb1-sys"
@@ -416,12 +444,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.4",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
  "num-traits",
 ]
 
@@ -431,7 +488,8 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]
@@ -477,10 +535,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkcs1"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "116bee8279d783c0cf370efa1a94632f2108e5ef0bb32df31f051647810a4e2c"
+dependencies = [
+ "der",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "pkcs8"
@@ -489,7 +567,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der",
+ "pem-rfc7468",
+ "pkcs1",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -530,9 +611,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -543,6 +636,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -570,6 +673,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rsa"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+dependencies = [
+ "byteorder",
+ "digest",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand 0.8.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -666,6 +798,18 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -877,7 +1021,9 @@ dependencies = [
  "p256",
  "p384",
  "pbkdf2",
+ "rand 0.8.4",
  "rand_core 0.6.3",
+ "rsa",
  "rusb",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,7 @@ p384 = { version = "0.8", default-features = false, features = ["ecdsa"] }
 pbkdf2 = { version = "0.9", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
-rand = "0.8"
 rand_core = { version = "0.6", features = ["std"] }
-rsa = "0.5"
 rusb = { version = "0.9", optional = true }
 sha2 = { version = "0.9", optional = true }
 signature = { version = "1.3.2", features = ["derive-preview"] }
@@ -51,6 +49,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 ed25519-dalek = "1"
 once_cell = "1"
 p256 = { version = "0.9", features = ["ecdsa"] }
+rsa = "0.5"
 
 [features]
 default = ["http", "passwords", "setup"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ p384 = { version = "0.8", default-features = false, features = ["ecdsa"] }
 pbkdf2 = { version = "0.9", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
+rand = "0.8"
 rand_core = { version = "0.6", features = ["std"] }
+rsa = "0.5"
 rusb = { version = "0.9", optional = true }
 sha2 = { version = "0.9", optional = true }
 signature = { version = "1.3.2", features = ["derive-preview"] }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ supported, please open an issue requesting support.
 | [Close Session]                | ✅     | ✅        | Terminate an encrypted session with the HSM |
 | [Create OTP AEAD]              | ⛔     | ⛔        | Create a Yubico OTP AEAD |
 | [Create Session]               | ✅     | ✅        | Initiate a new encrypted session with the HSM |
-| [Decrypt OAEP]                 | ⛔     | ⛔        | Decrypt data encrypted with RSA-OAEP |
+| [Decrypt OAEP]                 | ✅     | ⛔        | Decrypt data encrypted with RSA-OAEP |
 | [Decrypt OTP]                  | ⛔     | ⛔        | Decrypt a Yubico OTP, obtaining counters and timer info |
 | [Decrypt PKCS1]                | ⛔     | ⛔        | Decrypt data encrypted with RSA-PKCS#1v1.5 |
 | [Delete Object]                | ✅     | ✅        | Delete an object of the given ID and type |

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,7 +48,7 @@ use {
     crate::{
         algorithm::Algorithm,
         ecdh::{self, commands::*},
-        rsa::{self, pkcs1::commands::*, pss::commands::*},
+        rsa::{pkcs1::commands::*, pss::commands::*},
         ssh::{self, commands::*},
     },
     sha2::{Digest, Sha256},

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,7 @@ use crate::{
     object::{self, commands::*, generate},
     opaque::{self, commands::*},
     otp::{self, commands::*},
+    rsa::{self, oaep::commands::*},
     serialization::{deserialize, serialize},
     session::{self, Session},
     template::{commands::*, Template},
@@ -196,6 +197,29 @@ impl Client {
     pub fn blink_device(&self, num_seconds: u8) -> Result<(), Error> {
         self.send_command(BlinkDeviceCommand { num_seconds })?;
         Ok(())
+    }
+
+    /// Decrypt data encrypted with RSA-OAEP
+    ///
+    /// <https://developers.yubico.com/YubiHSM2/Commands/Decrypt_Oaep.html>
+    pub fn decrypt_oaep<T>(
+        &self,
+        key_id: object::Id,
+        mgf1_hash_alg: rsa::mgf::Algorithm,
+        data: T,
+        label_hash: Vec<u8>,
+    ) -> Result<rsa::oaep::DecryptedData, Error>
+    where
+        T: Into<Vec<u8>>,
+    {
+        Ok(self
+            .send_command(DecryptOaepCommand {
+                key_id,
+                mgf1_hash_alg,
+                data: data.into(),
+                label_hash,
+            })?
+            .into())
     }
 
     /// Delete an object of the given ID and type.

--- a/src/connector/http/client/connection.rs
+++ b/src/connector/http/client/connection.rs
@@ -13,8 +13,8 @@ use std::{
 
 use super::{error::Error, path::PathBuf, request, response, HTTP_VERSION, USER_AGENT};
 
-/// Default timeout in milliseconds (5 seconds)
-const DEFAULT_TIMEOUT_MS: u64 = 5000;
+/// Default timeout in milliseconds (20 seconds)
+const DEFAULT_TIMEOUT_MS: u64 = 20000;
 
 /// Options when building a `Connection`
 pub struct ConnectionOptions {

--- a/src/rsa/oaep.rs
+++ b/src/rsa/oaep.rs
@@ -1,5 +1,8 @@
 //! RSA encryption with Optimal Asymmetric Encryption Padding (OAEP)
 
 mod algorithm;
+pub(crate) mod commands;
+mod decrypted_data;
 
 pub use self::algorithm::Algorithm;
+pub use self::decrypted_data::DecryptedData;

--- a/src/rsa/oaep/commands.rs
+++ b/src/rsa/oaep/commands.rs
@@ -1,0 +1,43 @@
+//! RSA OAEP commands
+
+use crate::{
+    command::{self, Command},
+    object,
+    response::Response,
+    rsa,
+};
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for `command::decrypt_rsa_oaep`
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct DecryptOaepCommand {
+    /// ID of the decryption key
+    pub key_id: object::Id,
+
+    /// Hash algorithm to use for MGF1
+    pub mgf1_hash_alg: rsa::mgf::Algorithm,
+
+    /// Data to be decrypted
+    pub data: Vec<u8>,
+
+    /// Hash of the OAEP label
+    pub label_hash: Vec<u8>,
+}
+
+impl Command for DecryptOaepCommand {
+    type ResponseType = DecryptOaepResponse;
+}
+
+/// RSA OAEP decrypted data
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DecryptOaepResponse(rsa::oaep::DecryptedData);
+
+impl Response for DecryptOaepResponse {
+    const COMMAND_CODE: command::Code = command::Code::DecryptOaep;
+}
+
+impl From<DecryptOaepResponse> for rsa::oaep::DecryptedData {
+    fn from(response: DecryptOaepResponse) -> rsa::oaep::DecryptedData {
+        response.0
+    }
+}

--- a/src/rsa/oaep/decrypted_data.rs
+++ b/src/rsa/oaep/decrypted_data.rs
@@ -1,0 +1,37 @@
+//! RSA OAEP decrypted data
+
+use serde::{Deserialize, Serialize};
+
+/// RSA OAEP decrypted data
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DecryptedData(pub Vec<u8>);
+
+#[allow(clippy::len_without_is_empty)]
+impl DecryptedData {
+    /// Unwrap inner byte vector
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+
+    /// Get length of the signature
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Get slice of the inner byte vector
+    pub fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+impl AsRef<[u8]> for DecryptedData {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Into<Vec<u8>> for DecryptedData {
+    fn into(self) -> Vec<u8> {
+        self.0
+    }
+}

--- a/tests/command/decrypt_oaep.rs
+++ b/tests/command/decrypt_oaep.rs
@@ -1,5 +1,5 @@
 use crate::{generate_asymmetric_key, TEST_KEY_ID};
-use rand::rngs::OsRng;
+use rand_core;
 use rsa::{self, PublicKey};
 use sha2::{self, Digest};
 
@@ -29,7 +29,7 @@ fn rsa_decrypt_oaep_test() {
     let rsa_exponent = rsa::BigUint::parse_bytes(b"65537", 10).unwrap();
     let rsa_public_key = rsa::RsaPublicKey::new(rsa_modulus, rsa_exponent).unwrap();
 
-    let mut rng = OsRng;
+    let mut rng = rand_core::OsRng;
     let ciphertext = rsa_public_key
         .encrypt(
             &mut rng,

--- a/tests/command/decrypt_oaep.rs
+++ b/tests/command/decrypt_oaep.rs
@@ -1,0 +1,55 @@
+use crate::{generate_asymmetric_key, TEST_KEY_ID};
+use rand::rngs::OsRng;
+use rsa::{self, PublicKey};
+use sha2::{self, Digest};
+
+use yubihsm::{asymmetric, Capability};
+
+/// Test RSA OAEP decryption
+#[test]
+fn rsa_decrypt_oaep_test() {
+    let client = crate::get_hsm_client();
+
+    generate_asymmetric_key(
+        &client,
+        asymmetric::Algorithm::Rsa2048,
+        Capability::DECRYPT_OAEP,
+    );
+
+    let raw_public_key = client
+        .get_public_key(TEST_KEY_ID)
+        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+
+    assert_eq!(raw_public_key.algorithm, asymmetric::Algorithm::Rsa2048);
+    assert_eq!(raw_public_key.bytes.len(), 256);
+
+    let plaintext = b"Secret message!";
+
+    let rsa_modulus = rsa::BigUint::from_bytes_be(raw_public_key.as_slice());
+    let rsa_exponent = rsa::BigUint::parse_bytes(b"65537", 10).unwrap();
+    let rsa_public_key = rsa::RsaPublicKey::new(rsa_modulus, rsa_exponent).unwrap();
+
+    let mut rng = OsRng;
+    let ciphertext = rsa_public_key
+        .encrypt(
+            &mut rng,
+            rsa::PaddingScheme::new_oaep::<sha2::Sha256>(),
+            plaintext,
+        )
+        .expect("Failed to encrypt");
+
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"");
+    let label_hash = hasher.finalize();
+
+    let decrypted_data = client
+        .decrypt_oaep(
+            TEST_KEY_ID,
+            yubihsm::rsa::mgf::Algorithm::Sha256,
+            ciphertext,
+            label_hash.to_vec(),
+        )
+        .unwrap();
+
+    assert_eq!(decrypted_data.as_slice(), plaintext);
+}

--- a/tests/command/generate_asymmetric_key.rs
+++ b/tests/command/generate_asymmetric_key.rs
@@ -25,6 +25,7 @@ fn ed25519_key_test() {
 }
 
 /// Generate an RSA2048 key
+#[cfg(not(feature = "mockhsm"))]
 #[test]
 fn rsa2048_key_test() {
     let client = crate::get_hsm_client();

--- a/tests/command/generate_asymmetric_key.rs
+++ b/tests/command/generate_asymmetric_key.rs
@@ -24,6 +24,29 @@ fn ed25519_key_test() {
     assert_eq!(&object_info.label.to_string(), TEST_KEY_LABEL);
 }
 
+/// Generate an RSA2048 key
+#[test]
+fn rsa2048_key_test() {
+    let client = crate::get_hsm_client();
+
+    let algorithm = asymmetric::Algorithm::Rsa2048;
+    let capabilities = Capability::DECRYPT_OAEP;
+
+    generate_asymmetric_key(&client, algorithm, capabilities);
+
+    let object_info = client
+        .get_object_info(TEST_KEY_ID, object::Type::AsymmetricKey)
+        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, object::Type::AsymmetricKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, object::Origin::Generated);
+    assert_eq!(&object_info.label.to_string(), TEST_KEY_LABEL);
+}
+
 /// Generate a NIST P-256 key
 #[cfg(not(feature = "mockhsm"))]
 #[test]

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -1,6 +1,7 @@
 //! Integration tests for YubiHSM 2 commands
 
 pub mod blink_device;
+#[cfg(not(feature = "mockhsm"))]
 pub mod decrypt_oaep;
 pub mod delete_object;
 pub mod device_info;

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -1,6 +1,7 @@
 //! Integration tests for YubiHSM 2 commands
 
 pub mod blink_device;
+pub mod decrypt_oaep;
 pub mod delete_object;
 pub mod device_info;
 pub mod export_wrapped;


### PR DESCRIPTION
Hi, I've been working with yubihsm2 in in Rust, and had to use the `decrypt_oaep` command, so I decided to make a contribution.

I've tested the code on a live device, and it seems to work fine. Hopefully the patch makes sense to you as well.

There are two points I'd like to additionally discuss (and potentially change during in this PR):

- I changed the default connection timeout (5 s -> 20 s) because RSA key generation takes quite some time. I could revert this and construct such a client specific to these tests, but it made sense to me to have default values that tolerate this command.
- I was thinking of making `decrypt_oaep` in `Client` a bit more "high level" by taking the OAEP label as a parameter, and make the function responsible for properly computing its hash and passing it on to low-level API. 