### PR TITLE
Bump `elliptic-curve` crates to v0.11-based releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +173,17 @@ name = "crypto-bigint"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -222,8 +239,17 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 dependencies = [
- "const-oid",
- "crypto-bigint",
+ "const-oid 0.6.2",
+ "crypto-bigint 0.2.11",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid 0.7.1",
 ]
 
 [[package]]
@@ -237,13 +263,13 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "e91ae02c7618ee05108cd86a0be2f5586d1f0d965bede7ecfd46815f1b860227"
 dependencies = [
- "der",
+ "der 0.5.1",
  "elliptic-curve",
- "hmac",
+ "rfc6979",
  "signature",
 ]
 
@@ -272,25 +298,26 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "1f01ff20862362c34074072c8be2de97399633d6b1d2114afa56bf77a8b7f0a4"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.3.2",
+ "der 0.5.1",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
  "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -340,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -378,13 +405,14 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "58e786b08b1c90389266b21e238894b88c03296b44db6c6a797484c6fb3e6e5a"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
  "sha3",
 ]
@@ -506,23 +534,25 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+checksum = "d0e0c5310031b5d4528ac6534bccc1446c289ac45c47b277d5aa91089c5f74fa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157"
+checksum = "755d8266e41f57bd8562ed9b6e93cdcf73ead050e1e8c3a27ea3871b6643a20c"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
 ]
 
 [[package]]
@@ -555,7 +585,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "116bee8279d783c0cf370efa1a94632f2108e5ef0bb32df31f051647810a4e2c"
 dependencies = [
- "der",
+ "der 0.4.4",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -566,10 +596,21 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
- "der",
+ "der 0.4.4",
  "pem-rfc7468",
  "pkcs1",
- "spki",
+ "spki 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der 0.5.1",
+ "spki 0.5.2",
  "zeroize",
 ]
 
@@ -685,6 +726,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint 0.3.2",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "rsa"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +750,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.7.6",
  "rand 0.8.4",
  "subtle",
  "zeroize",
@@ -719,6 +771,19 @@ name = "ryu"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der 0.5.1",
+ "generic-array",
+ "pkcs8 0.8.0",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -817,7 +882,17 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
 dependencies = [
- "der",
+ "der 0.4.4",
+]
+
+[[package]]
+name = "spki"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a277a21925310de1d31bb6b021da3550b00e9127096ef84ee38f44609925c4"
+dependencies = [
+ "base64ct",
+ "der 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ block-modes = "0.8"
 ccm = { version = "0.4", optional = true, features = ["std"] }
 cmac = "0.6"
 digest = { version = "0.9", optional = true, default-features = false }
-ecdsa = { version = "0.12", default-features = false }
+ecdsa = { version = "0.13", default-features = false }
 ed25519 = "1.3"
 ed25519-dalek = { version = "1", optional = true }
 hmac = { version = "0.11", optional = true }
-k256 = { version = "0.9", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
+k256 = { version = "0.10", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
-p256 = { version = "0.9", default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.8", default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.10", default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.9", default-features = false, features = ["ecdsa"] }
 pbkdf2 = { version = "0.9", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
@@ -48,14 +48,14 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 [dev-dependencies]
 ed25519-dalek = "1"
 once_cell = "1"
-p256 = { version = "0.9", features = ["ecdsa"] }
+p256 = { version = "0.10", features = ["ecdsa"] }
 rsa = "0.5"
 
 [features]
 default = ["http", "passwords", "setup"]
 http-server = ["tiny_http"]
 http = []
-mockhsm = ["ccm", "digest", "ed25519-dalek", "p256/ecdsa", "secp256k1"]
+mockhsm = ["ccm", "digest", "ecdsa/arithmetic", "ed25519-dalek", "p256/ecdsa", "secp256k1"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 secp256k1 = ["k256"]
 setup = ["passwords", "serde_json", "uuid/serde"]

--- a/src/connector/usb/config.rs
+++ b/src/connector/usb/config.rs
@@ -3,9 +3,6 @@
 use crate::device::SerialNumber;
 use serde::{Deserialize, Serialize};
 
-/// Default timeouts for reading and writing (1 second)
-pub const DEFAULT_TIMEOUT_MILLIS: u64 = 1000;
-
 /// Configuration for connecting to the YubiHSM via USB
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(docsrs, doc(cfg(feature = "usb")))]
@@ -17,11 +14,16 @@ pub struct UsbConfig {
     pub timeout_ms: u64,
 }
 
+impl UsbConfig {
+    /// Default timeout for USB communication (30 seconds)
+    pub const DEFAULT_TIMEOUT_MILLIS: u64 = 30_000;
+}
+
 impl Default for UsbConfig {
     fn default() -> UsbConfig {
         UsbConfig {
             serial: None,
-            timeout_ms: DEFAULT_TIMEOUT_MILLIS,
+            timeout_ms: Self::DEFAULT_TIMEOUT_MILLIS,
         }
     }
 }

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -1,15 +1,9 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) tests
 
 use ::ecdsa::{
-    elliptic_curve::{
-        consts::U1,
-        generic_array::ArrayLength,
-        sec1::{UncompressedPointSize, UntaggedPointSize},
-        weierstrass::{Curve, PointCompression},
-    },
+    elliptic_curve::{sec1, FieldSize, PointCompression, PrimeCurve},
     signature::Verifier,
 };
-use std::ops::Add;
 use yubihsm::{
     asymmetric::signature::Signer as _,
     ecdsa::{self, algorithm::CurveAlgorithm, NistP256},
@@ -36,9 +30,8 @@ const TEST_MESSAGE: &[u8] =
 /// Create the signer for this test
 fn create_signer<C>(key_id: object::Id) -> ecdsa::Signer<C>
 where
-    C: Curve + CurveAlgorithm + PointCompression,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + CurveAlgorithm + PointCompression,
+    FieldSize<C>: sec1::ModulusSize,
 {
     let client = crate::get_hsm_client();
     create_yubihsm_key(&client, key_id, C::asymmetric_algorithm());


### PR DESCRIPTION
Updates the RustCrypto elliptic curve crates to the following releases:

- `ecdsa` v0.13
- `k256` v0.10
- `p256` v0.10
- `p384` v0.9