### PR TITLE
Bump asymmetric crypto dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -56,7 +56,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -100,7 +100,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56.0 # MSRV
+          toolchain: 1.57.0 # MSRV
           components: clippy
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,15 +32,6 @@ checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
 
 [[package]]
 name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -69,7 +60,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
  "generic-array",
 ]
 
@@ -146,15 +145,15 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
-
-[[package]]
-name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "const-oid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cpufeatures"
@@ -167,25 +166,34 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
-dependencies = [
- "generic-array",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac961631d66e80ac7ac2ac01320628ce214ad2b5ef0a88ceb86eae459069e2b4"
+dependencies = [
+ "generic-array",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -215,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -232,21 +240,23 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
-dependencies = [
- "const-oid 0.6.2",
- "crypto-bigint 0.2.11",
-]
-
-[[package]]
-name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid 0.7.1",
+ "crypto-bigint 0.3.2",
+ "pem-rfc7468",
+]
+
+[[package]]
+name = "der"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+dependencies = [
+ "const-oid 0.9.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -259,12 +269,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.13.4"
+name = "digest"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "der 0.5.1",
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9810024e6cddd0606273183fbb07af8e7f4dbf3818b492ec3481e2041c73f444"
+dependencies = [
+ "der 0.6.0",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -289,22 +310,24 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "4f6664c6a37892ed55da8dda26a99e6ccc783f0c72fa3c2eeaa00ed30d8f4d9a"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.3.2",
- "der 0.5.1",
+ "crypto-bigint 0.4.7",
+ "der 0.6.0",
+ "digest 0.10.3",
  "ff",
  "generic-array",
  "group",
+ "pkcs8 0.9.0",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -313,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -365,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -376,12 +399,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -403,15 +425,14 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "b953594f084668b4138b8b2fa63ed9776b476c58aa507d575c5206e8bfe5dc4a"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.2",
  "sha3",
 ]
 
@@ -471,11 +492,10 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
 dependencies = [
- "autocfg 0.1.8",
  "byteorder",
  "lazy_static",
  "libm",
@@ -493,7 +513,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -503,7 +523,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -514,7 +534,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm",
 ]
 
@@ -541,41 +561,40 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19736d80675fbe9fe33426268150b951a3fb8f5cfca2a23a17c85ef3adb24e3b"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d8266e41f57bd8562ed9b6e93cdcf73ead050e1e8c3a27ea3871b6643a20c"
+checksum = "70723b6e03216e79df3765a7e4cdf39746c4a2392ba4bdb458111a939494cc1d"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sec1",
+ "sha2 0.10.2",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "crypto-mac",
+ "digest 0.10.3",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
 dependencies = [
  "base64ct",
 ]
@@ -588,25 +607,12 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkcs1"
-version = "0.2.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116bee8279d783c0cf370efa1a94632f2108e5ef0bb32df31f051647810a4e2c"
+checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
 dependencies = [
- "der 0.4.5",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
-dependencies = [
- "der 0.4.5",
- "pem-rfc7468",
- "pkcs1",
- "spki 0.4.1",
+ "der 0.5.1",
+ "pkcs8 0.8.0",
  "zeroize",
 ]
 
@@ -619,6 +625,16 @@ dependencies = [
  "der 0.5.1",
  "spki 0.5.4",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.0",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -670,7 +686,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
 ]
@@ -724,31 +739,31 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "6c0788437d5ee113c49af91d3594ebc4fcdcc962f8b6df5aa1c3eeafd8ad95de"
 dependencies = [
- "crypto-bigint 0.3.2",
+ "crypto-bigint 0.4.7",
  "hmac",
  "zeroize",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
 dependencies = [
  "byteorder",
- "digest",
- "lazy_static",
+ "digest 0.10.3",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.7.6",
- "rand 0.8.5",
+ "pkcs8 0.8.0",
+ "rand_core 0.6.3",
+ "smallvec",
  "subtle",
  "zeroize",
 ]
@@ -771,13 +786,14 @@ checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "der 0.5.1",
+ "base16ct",
+ "der 0.6.0",
  "generic-array",
- "pkcs8 0.8.0",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -819,41 +835,50 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "block-buffer",
- "digest",
+ "digest 0.10.3",
  "keccak",
- "opaque-debug",
 ]
 
 [[package]]
 name = "signature"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 dependencies = [
- "digest",
+ "digest 0.10.3",
  "rand_core 0.6.3",
  "signature_derive",
 ]
 
 [[package]]
 name = "signature_derive"
-version = "1.0.0-pre.3"
+version = "1.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffba76095b73f87680d2cf325a8000d5fc507ca6c20c4f7e2747405550620d90"
+checksum = "a7b87d3bd8d687b9265557e613e59ddc5dcb2ed6395523846d2fe76736073d5c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -875,21 +900,22 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
-dependencies = [
- "der 0.4.5",
-]
-
-[[package]]
-name = "spki"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
  "der 0.5.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.0",
 ]
 
 [[package]]
@@ -1075,7 +1101,7 @@ dependencies = [
  "block-modes",
  "ccm",
  "cmac",
- "digest",
+ "digest 0.10.3",
  "ecdsa",
  "ed25519",
  "ed25519-dalek",
@@ -1091,7 +1117,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.2",
  "signature",
  "subtle",
  "thiserror",
@@ -1103,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 categories = ["cryptography", "hardware-support"]
 keywords = ["ecdsa", "ed25519", "hmac", "hsm", "yubikey"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 aes = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,21 @@ bitflags = "1"
 block-modes = "0.8"
 ccm = { version = "0.4", optional = true, features = ["std"] }
 cmac = "0.6"
-digest = { version = "0.9", optional = true, default-features = false }
-ecdsa = { version = "0.13", default-features = false }
+digest = { version = "0.10", optional = true, default-features = false }
+ecdsa = { version = "0.14", default-features = false }
 ed25519 = "1.3"
 ed25519-dalek = { version = "1", optional = true }
-hmac = { version = "0.11", optional = true }
-k256 = { version = "0.10", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
+hmac = { version = "0.12", optional = true }
+k256 = { version = "0.11", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
-p256 = { version = "0.10", default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.9", default-features = false, features = ["ecdsa"] }
-pbkdf2 = { version = "0.9", optional = true, default-features = false }
+p256 = { version = "0.11", default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.11", default-features = false, features = ["ecdsa"] }
+pbkdf2 = { version = "0.11", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
 rand_core = { version = "0.6", features = ["std"] }
 rusb = { version = "0.9", optional = true }
-sha2 = { version = "0.9", optional = true }
+sha2 = { version = "0.10", optional = true }
 signature = { version = "1.3.2", features = ["derive-preview"] }
 subtle = "2"
 thiserror = "1"
@@ -48,8 +48,8 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 [dev-dependencies]
 ed25519-dalek = "1"
 once_cell = "1"
-p256 = { version = "0.10", features = ["ecdsa"] }
-rsa = "0.5"
+p256 = { version = "0.11", features = ["ecdsa"] }
+rsa = "0.6"
 
 [features]
 default = ["http", "passwords", "setup"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust **1.56** or newer.
+This crate requires Rust **1.57** or newer.
 
 ## Supported Commands
 

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -13,6 +13,8 @@ use signature::{DigestSigner, Error};
 
 #[cfg(feature = "secp256k1")]
 use super::Secp256k1;
+#[cfg(feature = "secp256k1")]
+use signature::digest::FixedOutput;
 
 /// ECDSA signature provider for yubihsm-client
 #[derive(signature::Signer)]
@@ -116,7 +118,7 @@ where
 #[cfg(feature = "secp256k1")]
 impl<D> DigestSigner<D, k256::ecdsa::recoverable::Signature> for Signer<Secp256k1>
 where
-    D: Digest<OutputSize = U32> + Clone + Default,
+    D: Digest<OutputSize = U32> + Clone + Default + FixedOutput,
 {
     /// Compute an Ethereum-style ECDSA/secp256k1 signature of the given digest
     fn try_sign_digest(&self, digest: D) -> Result<k256::ecdsa::recoverable::Signature, Error> {

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -29,7 +29,6 @@ use ::ecdsa::{
     hazmat::SignPrimitive,
 };
 use ::hmac::{Hmac, Mac};
-use cmac::crypto_mac::NewMac;
 use ed25519_dalek as ed25519;
 use rand_core::{OsRng, RngCore};
 use sha2::Sha256;
@@ -625,7 +624,8 @@ fn sign_ecdsa(state: &State, cmd_data: &[u8]) -> response::Message {
             Payload::EcdsaNistP256(secret_key) => {
                 let k = p256::Scalar::random(&mut OsRng);
                 let z =
-                    p256::Scalar::from_be_bytes_reduced(*GenericArray::from_slice(&command.digest));
+                    p256::Scalar::from_be_bytes_reduced(*GenericArray::from_slice(&command.digest))
+                        .to_bytes();
                 let signature = secret_key
                     .to_nonzero_scalar()
                     .try_sign_prehashed(k, z)
@@ -638,7 +638,8 @@ fn sign_ecdsa(state: &State, cmd_data: &[u8]) -> response::Message {
                 let k = k256::Scalar::random(&mut OsRng);
                 let z = <k256::Scalar as Reduce<U256>>::from_be_bytes_reduced(
                     *GenericArray::from_slice(&command.digest),
-                );
+                )
+                .to_bytes();
                 let signature = secret_key
                     .to_nonzero_scalar()
                     .try_sign_prehashed(k, z)

--- a/src/mockhsm/digest.rs
+++ b/src/mockhsm/digest.rs
@@ -1,9 +1,7 @@
 //! Mock `Digest` type for use with ECDSA signatures
 
 use crate::ecdsa::commands::SignEcdsaCommand;
-use digest::{
-    consts::U32, generic_array::GenericArray, BlockInput, FixedOutputDirty, Output, Reset, Update,
-};
+use digest::{consts::U32, generic_array::GenericArray, Output, OutputSizeUser, Reset, Update};
 
 /// Mock 256-bit digest
 #[derive(Clone, Default)]
@@ -20,12 +18,8 @@ impl From<&SignEcdsaCommand> for MockDigest256 {
     }
 }
 
-impl BlockInput for MockDigest256 {
-    type BlockSize = U32;
-}
-
 impl Update for MockDigest256 {
-    fn update(&mut self, _data: impl AsRef<[u8]>) {
+    fn update(&mut self, _: &[u8]) {
         unimplemented!("use explicit conversion from SignEcdsaCommand");
     }
 }
@@ -36,10 +30,6 @@ impl Reset for MockDigest256 {
     }
 }
 
-impl FixedOutputDirty for MockDigest256 {
+impl OutputSizeUser for MockDigest256 {
     type OutputSize = U32;
-
-    fn finalize_into_dirty(&mut self, output: &mut Output<Self>) {
-        *output = self.output.take().expect("never initialized!");
-    }
 }

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -84,6 +84,6 @@ fn ecdsa_secp256k1_sign_recoverable_test() {
     let signature: k256::ecdsa::recoverable::Signature = signer.sign(TEST_MESSAGE);
     assert!(verify_key.verify(TEST_MESSAGE, &signature).is_ok());
 
-    let recovered_verify_key = signature.recover_verify_key(TEST_MESSAGE).unwrap();
+    let recovered_verify_key = signature.recover_verifying_key(TEST_MESSAGE).unwrap();
     assert_eq!(verify_key, recovered_verify_key);
 }


### PR DESCRIPTION
Bump asymmetric crypto dependencies from Rust Crypto.

This is prompted by the conflict below in [ethers-rs](https://github.com/gakonst/ethers-rs) after the following change:

```diff
diff --git a/ethers-core/Cargo.toml b/ethers-core/Cargo.toml
index 00fa752..11d4a2c 100644
--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -18,7 +18,7 @@ rlp-derive = { version = "0.1.0", default-features = false }
-k256 = { version = "0.10.4", default-features = false, features = ["keccak256", "ecdsa", "std"] }
+k256 = { version = "0.11.2", default-features = false, features = ["keccak256", "ecdsa", "std"] }
```

Conflict:

```
error: failed to select a version for `signature`.
    ... required by package `ecdsa v0.13.3`
    ... which satisfies dependency `ecdsa = "^0.13"` of package `yubihsm v0.40.0`
    ... which satisfies dependency `yubihsm = "^0.40.0"` of package `ethers-signers v0.13.0 (/Users/abiro/repos/ethers-rs/ethers-signers)`
    ... which satisfies path dependency `ethers-signers` (locked to 0.13.0) of package `ethers v0.13.0 (/Users/abiro/repos/ethers-rs)`
    ... which satisfies path dependency `ethers` (locked to 0.13.0) of package `ethers-wasm v0.1.0 (/Users/abiro/repos/ethers-rs/examples/ethers-wasm)`
versions that meet the requirements `>=1.3.1, <1.5` are: 1.4.0, 1.3.2, 1.3.1

all possible versions conflict with previously selected packages.

  previously selected package `signature v1.5.0`
    ... which satisfies dependency `signature = "^1.5"` of package `ecdsa v0.14.2`
    ... which satisfies dependency `ecdsa-core = "^0.14"` of package `k256 v0.11.2`
    ... which satisfies dependency `k256 = "^0.11.2"` of package `ethers-core v0.13.0 (/Users/abiro/repos/ethers-rs/ethers-core)`
    ... which satisfies path dependency `ethers-core` (locked to 0.13.0) of package `ethers v0.13.0 (/Users/abiro/repos/ethers-rs)`
    ... which satisfies path dependency `ethers` (locked to 0.13.0) of package `ethers-wasm v0.1.0 (/Users/abiro/repos/ethers-rs/examples/ethers-wasm)`

failed to select a version for `signature` which could resolve this conflict
```