### PR TITLE
Update symmetric dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,23 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "ae06cea71059b6b79d879afcdd237a33ac61afc052fdd605815e6f3916254abf"
 dependencies = [
+ "crypto-common",
  "generic-array",
- "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
@@ -73,26 +72,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-modes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding",
- "cipher",
-]
-
-[[package]]
 name = "block-padding"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -102,9 +103,9 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "ccm"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9cf981c7e62b6fb02225592ee7ebf221e0b0b5317984a57a1e9d21af20e317"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
 dependencies = [
  "aead",
  "cipher",
@@ -126,21 +127,23 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
 name = "cmac"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70e37282d9624283878ffda1d1e53883bcf868cf441bddda44127620b39572d"
+checksum = "606383658416244b8dc4b36f864ec1f86cb922b95c41a908fd07aeb01cad06fa"
 dependencies = [
- "crypto-mac",
+ "cipher",
  "dbl",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -188,30 +191,20 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
  "typenum",
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "cipher",
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
 dependencies = [
  "cipher",
 ]
@@ -415,6 +408,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1098,7 +1101,7 @@ version = "0.41.0-pre"
 dependencies = [
  "aes",
  "bitflags",
- "block-modes",
+ "cbc",
  "ccm",
  "cmac",
  "digest 0.10.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-aes = "0.7"
+aes = "0.8"
 bitflags = "1"
-block-modes = "0.8"
-ccm = { version = "0.4", optional = true, features = ["std"] }
-cmac = "0.6"
+ccm = { version = "0.5", optional = true, features = ["std"] }
+cmac = "0.7"
+cbc = "0.1"
 digest = { version = "0.10", optional = true, default-features = false }
 ecdsa = { version = "0.14", default-features = false }
 ed25519 = "1.3"

--- a/src/command/message.rs
+++ b/src/command/message.rs
@@ -11,11 +11,7 @@
 use super::MAX_MSG_SIZE;
 use crate::{
     command, connector,
-    session::{
-        self,
-        securechannel::{Mac, MAC_SIZE},
-        ErrorKind::ProtocolError,
-    },
+    session::{self, securechannel::Mac, ErrorKind::ProtocolError},
     uuid::{self, Uuid},
 };
 
@@ -134,7 +130,7 @@ impl Message {
 
                 let id = session::Id::from_u8(bytes.remove(0))?;
 
-                if bytes.len() < MAC_SIZE {
+                if bytes.len() < Mac::BYTE_SIZE {
                     fail!(
                         ProtocolError,
                         "expected MAC for {:?} but command data is too short: {}",
@@ -143,7 +139,7 @@ impl Message {
                     );
                 }
 
-                let mac_index = bytes.len() - MAC_SIZE;
+                let mac_index = bytes.len() - Mac::BYTE_SIZE;
 
                 (Some(id), Some(Mac::from_slice(&bytes.split_off(mac_index))))
             }
@@ -168,7 +164,7 @@ impl Message {
         }
 
         if self.mac.is_some() {
-            result += MAC_SIZE;
+            result += Mac::BYTE_SIZE;
         }
 
         result

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -9,7 +9,7 @@ use crate::{
     wrap, Algorithm, Capability, Domain,
 };
 use aes::cipher::consts::{U13, U8};
-use ccm::aead::{AeadInPlace, NewAead};
+use ccm::aead::{AeadInPlace, KeyInit};
 use std::collections::{btree_map::Iter as MapIter, BTreeMap as Map};
 
 /// AES-CCM with a 128-bit key
@@ -29,7 +29,8 @@ pub(crate) enum AesCcmKey {
 }
 
 impl AesCcmKey {
-    /// Encrypt data in-place
+    /// Encrypt data in-place.
+    #[allow(clippy::ptr_arg)]
     pub fn encrypt_in_place(
         &self,
         nonce: &wrap::Nonce,
@@ -47,7 +48,8 @@ impl AesCcmKey {
         .map_err(|_| format_err!(ErrorKind::CryptoError, "error encrypting wrapped object!").into())
     }
 
-    /// Decrypt data in-place
+    /// Decrypt data in-place.
+    #[allow(clippy::ptr_arg)]
     pub fn decrypt_in_place(
         &self,
         nonce: &wrap::Nonce,

--- a/src/response/message.rs
+++ b/src/response/message.rs
@@ -6,11 +6,7 @@
 
 use crate::{
     command, connector, response,
-    session::{
-        self,
-        securechannel::{Mac, MAC_SIZE},
-        ErrorKind::ProtocolError,
-    },
+    session::{self, securechannel::Mac, ErrorKind::ProtocolError},
 };
 
 #[cfg(feature = "mockhsm")]
@@ -74,11 +70,11 @@ impl Message {
         };
 
         let mac = if has_rmac(code) {
-            if bytes.len() < MAC_SIZE {
+            if bytes.len() < Mac::BYTE_SIZE {
                 fail!(ProtocolError, "missing R-MAC for {:?}", code,);
             }
 
-            let mac_index = bytes.len() - MAC_SIZE;
+            let mac_index = bytes.len() - Mac::BYTE_SIZE;
             Some(Mac::from_slice(&bytes.split_off(mac_index)))
         } else {
             None
@@ -157,7 +153,7 @@ impl Message {
         }
 
         if self.mac.is_some() {
-            result += MAC_SIZE;
+            result += Mac::BYTE_SIZE;
         }
 
         result

--- a/src/session/message.rs
+++ b/src/session/message.rs
@@ -9,7 +9,7 @@
 use uuid::Uuid;
 use super::{
     error::{session::Error, session::ErrorKind::ProtocolError},
-    securechannel::{Mac, MAC_SIZE},
+    securechannel::{Mac, Mac::BYTE_SIZE},
 };
 use crate::{command, response, session};
 #[cfg(feature = "mockhsm")]
@@ -131,7 +131,7 @@ impl command::Message {
 
                 let id = session::Id::new(bytes.remove(0))?;
 
-                if bytes.len() < MAC_SIZE {
+                if bytes.len() < Mac::BYTE_SIZE {
                     fail!(
                         ProtocolError,
                         "expected MAC for {:?} but command data is too short: {}",
@@ -140,7 +140,7 @@ impl command::Message {
                     );
                 }
 
-                let mac_index = bytes.len() - MAC_SIZE;
+                let mac_index = bytes.len() - Mac::BYTE_SIZE;
 
                 (Some(id), Some(Mac::from_slice(&bytes.split_off(mac_index))))
             }
@@ -165,7 +165,7 @@ impl command::Message {
         }
 
         if self.mac.is_some() {
-            result += MAC_SIZE;
+            result += Mac::BYTE_SIZE;
         }
 
         result
@@ -245,11 +245,11 @@ impl response::Message {
         };
 
         let mac = if has_rmac(code) {
-            if bytes.len() < MAC_SIZE {
+            if bytes.len() < Mac::BYTE_SIZE {
                 fail!(ProtocolError, "missing R-MAC for {:?}", code,);
             }
 
-            let mac_index = bytes.len() - MAC_SIZE;
+            let mac_index = bytes.len() - Mac::BYTE_SIZE;
             Some(Mac::from_slice(&bytes.split_off(mac_index)))
         } else {
             None
@@ -331,7 +331,7 @@ impl response::Message {
         }
 
         if self.mac.is_some() {
-            result += MAC_SIZE;
+            result += Mac::BYTE_SIZE;
         }
 
         result

--- a/src/session/securechannel/kdf.rs
+++ b/src/session/securechannel/kdf.rs
@@ -4,7 +4,7 @@
 
 use super::{Context, KEY_SIZE};
 use aes::Aes128;
-use cmac::{crypto_mac::Mac, crypto_mac::NewMac, Cmac};
+use cmac::{Cmac, Mac};
 
 /// Derive a slice of output data using SCP03's KDF
 pub fn derive(mac_key: &[u8], derivation_constant: u8, context: &Context, output: &mut [u8]) {

--- a/src/session/securechannel/mac.rs
+++ b/src/session/securechannel/mac.rs
@@ -7,27 +7,27 @@
 //! lower (~2^32 messages).
 
 use crate::session;
-use cmac::crypto_mac::generic_array::{typenum::U16, GenericArray};
+use cmac::digest::generic_array::{typenum::U16, GenericArray};
 use std::fmt;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
-/// Size of the MAC in bytes: SCP03 truncates it to 8-bytes
-pub const MAC_SIZE: usize = 8;
-
 /// Message Authentication Codes used to verify messages
 #[derive(Zeroize)]
 #[zeroize(drop)]
-pub struct Mac([u8; MAC_SIZE]);
+pub struct Mac([u8; Self::BYTE_SIZE]);
 
 impl Mac {
+    /// Size of the MAC in bytes: SCP03 truncates it to 8-bytes
+    pub const BYTE_SIZE: usize = 8;
+
     /// Create a new MAC tag from a slice
     ///
     /// Panics if the slice is not 8-bytes
     pub fn from_slice(slice: &[u8]) -> Self {
         assert_eq!(slice.len(), 8, "MAC must be 8-bytes long");
 
-        let mut mac = [0u8; MAC_SIZE];
+        let mut mac = [0u8; Self::BYTE_SIZE];
         mac.copy_from_slice(slice);
         Mac(mac)
     }
@@ -65,6 +65,6 @@ impl fmt::Debug for Mac {
 
 impl<'a> From<&'a GenericArray<u8, U16>> for Mac {
     fn from(array: &'a GenericArray<u8, U16>) -> Self {
-        Self::from_slice(&array.as_slice()[..MAC_SIZE])
+        Self::from_slice(&array.as_slice()[..Self::BYTE_SIZE])
     }
 }


### PR DESCRIPTION
Updates the following to use the latest RustCrypto symmetric crate releases:

- `aes` v0.8
- `ccm` v0.5
- `cmac` v0.7
- `cbc` v0.1 (replacing `block-modes`)