### PR TITLE
v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.41.0 (2022-08-02)
+### Changed
+- Bump `uuid` to v1.0 ([#321])
+- Bump asymmetric crypto dependencies; MSRV 1.57 ([#325])
+- Bump symmetric crate dependencies ([#337])
+  - `aes` v0.8
+  - `ccm` v0.5
+  - `cmac` v0.7
+  - Replace `block-modes` with `cbc` v0.1
+
+[#321]: https://github.com/iqlusioninc/yubihsm.rs/pull/321
+[#325]: https://github.com/iqlusioninc/yubihsm.rs/pull/325
+[#337]: https://github.com/iqlusioninc/yubihsm.rs/pull/337
+
 ## 0.40.0 (2021-12-15)
 ### Added
 - Support for `decrypt_oaep` command ([#277])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "yubihsm"
-version = "0.41.0-pre"
+version = "0.41.0"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubihsm"
-version = "0.41.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.41.0"
 description = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,7 @@
 //! [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
 
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.40.0"
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubihsm.rs/main/img/logo.png"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Changed
- Bump `uuid` to v1.0 ([#321])
- Bump asymmetric crypto dependencies; MSRV 1.57 ([#325])
- Bump symmetric crate dependencies ([#337])
  - `aes` v0.8
  - `ccm` v0.5
  - `cmac` v0.7
  - Replace `block-modes` with `cbc` v0.1

[#321]: https://github.com/iqlusioninc/yubihsm.rs/pull/321
[#325]: https://github.com/iqlusioninc/yubihsm.rs/pull/325
[#337]: https://github.com/iqlusioninc/yubihsm.rs/pull/337