### PR TITLE
Impl `signature::hazmat::PrehashSigner` for ECDSA signer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ ed25519-dalek = { version = "1", optional = true }
 hmac = { version = "0.12", optional = true }
 k256 = { version = "0.11", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
 log = "0.4"
-p256 = { version = "0.11", default-features = false, features = ["ecdsa-core"] }
+p256 = { version = "0.11", default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.11", default-features = false, features = ["ecdsa"] }
 pbkdf2 = { version = "0.11", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
@@ -37,7 +37,7 @@ serde_json = { version = "1", optional = true }
 rand_core = { version = "0.6", features = ["std"] }
 rusb = { version = "0.9", optional = true }
 sha2 = { version = "0.10", optional = true }
-signature = { version = "1.6.0", features = ["derive-preview"] }
+signature = { version = "1.6.3", features = ["derive-preview", "hazmat-preview"] }
 subtle = "2"
 thiserror = "1"
 time = { version = "0.3", features = ["serde"] }


### PR DESCRIPTION
Support for signing raw digests via a trait-based abstraction