### PR TITLE
Bump asymmetric crypto dependencies; MSRV 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -56,7 +56,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -100,7 +100,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0 # MSRV
+          toolchain: 1.65.0 # MSRV
           components: clippy
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
@@ -52,15 +52,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -143,20 +134,14 @@ checksum = "606383658416244b8dc4b36f864ec1f86cb922b95c41a908fd07aeb01cad06fa"
 dependencies = [
  "cipher",
  "dbl",
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
-name = "const-oid"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cpufeatures"
@@ -169,22 +154,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "071c0f5945634bc9ba7a452f492377dd6b1993665ddb58f28704119b32f07a9a"
 dependencies = [
  "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -196,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -211,13 +186,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "digest",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
@@ -233,32 +210,13 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
 dependencies = [
- "const-oid 0.7.1",
- "crypto-bigint 0.3.2",
+ "const-oid",
  "pem-rfc7468",
-]
-
-[[package]]
-name = "der"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
-dependencies = [
- "const-oid 0.9.1",
  "zeroize",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -267,18 +225,19 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "d1b0a1222f8072619e8a6b667a854020a03d363738303203c09468b3424a420a"
 dependencies = [
- "der 0.6.0",
+ "der",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -286,42 +245,42 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "7bd577ba9d4bcab443cac60003d8fd32c638e7024a3ec92c200d7af5d2c397ed"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der 0.6.0",
- "digest 0.10.6",
+ "crypto-bigint",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
+ "pkcs8",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -329,13 +288,19 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "generic-array"
@@ -345,17 +310,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "zeroize",
 ]
 
 [[package]]
@@ -366,17 +321,17 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -386,7 +341,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -413,24 +368,16 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "955890845095ccf31ef83ad41a05aabb4d8cc23dc3cac5a9f5c89cf26dd0da75"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
- "sha3",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
-dependencies = [
- "cpufeatures",
+ "once_cell",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -447,6 +394,12 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libm"
@@ -483,11 +436,11 @@ checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
- "libm",
+ "libm 0.2.6",
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -520,91 +473,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
+ "libm 0.2.6",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.11.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm 0.1.4",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
 dependencies = [
- "digest 0.10.6",
+ "digest",
+ "hmac",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "178ba28ece1961eafdff1991bd1744c29564cbab5d803f3ccb4a4895a6c550a7"
 dependencies = [
- "der 0.5.1",
- "pkcs8 0.8.0",
+ "der",
+ "pkcs8",
+ "spki",
  "zeroize",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
 dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.0",
- "spki 0.6.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -614,10 +564,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -639,35 +604,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -677,16 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -695,45 +628,35 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "a7bc1d34159d63536b4d89944e9ab5bb952f45db6fa0b8b03c2f8c09fb5b7171"
 dependencies = [
  "byteorder",
- "digest 0.10.6",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.8.0",
- "rand_core 0.6.4",
- "smallvec",
+ "pkcs8",
+ "rand_core",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -756,14 +679,14 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
  "base16ct",
- "der 0.6.0",
+ "der",
  "generic-array",
- "pkcs8 0.9.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -801,54 +724,31 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
-dependencies = [
- "digest 0.10.6",
- "keccak",
+ "digest",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
- "digest 0.10.6",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
  "signature_derive",
 ]
 
 [[package]]
 name = "signature_derive"
-version = "1.0.0-pre.7"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e6310f022b5c02b3bba689166e833f6b96994a6ce1f138b653d2fd0519920f"
+checksum = "ede930749cca4e3a3df7e37b5f0934a55693e01d028d7a4e506b44cbc059d95a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -869,22 +769,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
  "base64ct",
- "der 0.5.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.0",
+ "der",
 ]
 
 [[package]]
@@ -1015,26 +905,20 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "yubihsm"
-version = "0.41.0"
+version = "0.42.0-pre"
 dependencies = [
  "aes",
  "bitflags",
  "cbc",
  "ccm",
  "cmac",
- "digest 0.10.6",
+ "digest",
  "ecdsa",
  "ed25519",
  "ed25519-dalek",
@@ -1045,12 +929,12 @@ dependencies = [
  "p256",
  "p384",
  "pbkdf2",
- "rand_core 0.6.4",
+ "rand_core",
  "rsa",
  "rusb",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2",
  "signature",
  "subtle",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubihsm"
-version = "0.41.0"
+version = "0.42.0-pre"
 description = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality
@@ -14,21 +14,21 @@ readme = "README.md"
 categories = ["cryptography", "hardware-support"]
 keywords = ["ecdsa", "ed25519", "hmac", "hsm", "yubikey"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 
 [dependencies]
 aes = "0.8"
 bitflags = "1"
 cmac = "0.7"
 cbc = "0.1"
-ecdsa = { version = "0.14", default-features = false }
-ed25519 = "1.3"
+ecdsa = { version = "0.16", default-features = false }
+ed25519 = "2"
 log = "0.4"
-p256 = { version = "0.11", default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.11", default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 serde = { version = "1", features = ["serde_derive"] }
 rand_core = { version = "0.6", features = ["std"] }
-signature = { version = "1.6.3", features = ["derive-preview", "hazmat-preview"] }
+signature = { version = "2", features = ["derive"] }
 subtle = "2"
 thiserror = "1"
 time = { version = "0.3", features = ["serde"] }
@@ -38,20 +38,20 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 # optional dependencies
 ccm = { version = "0.5", optional = true, features = ["std"] }
 digest = { version = "0.10", optional = true, default-features = false }
-ed25519-dalek = { version = "1", optional = true }
+ed25519-dalek = { version = "=2.0.0-pre.0", optional = true, features = ["rand_core"] }
 hmac = { version = "0.12", optional = true }
-k256 = { version = "0.11", optional = true, features = ["ecdsa", "keccak256", "sha256"] }
-pbkdf2 = { version = "0.11", optional = true, default-features = false }
+k256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
+pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
 serde_json = { version = "1", optional = true }
 rusb = { version = "0.9", optional = true }
 sha2 = { version = "0.10", optional = true }
 tiny_http = { version = "0.12", optional = true }
 
 [dev-dependencies]
-ed25519-dalek = "1"
+ed25519-dalek = "=2.0.0-pre.0"
 once_cell = "1"
-p256 = { version = "0.11", features = ["ecdsa"] }
-rsa = "0.6"
+p256 = { version = "0.13", features = ["ecdsa"] }
+rsa = "0.9.0-pre.0"
 
 [features]
 default = ["http", "passwords", "setup"]

--- a/src/asymmetric/public_key.rs
+++ b/src/asymmetric/public_key.rs
@@ -2,7 +2,7 @@
 
 use crate::{asymmetric, ecdsa::algorithm::CurveAlgorithm, ed25519};
 use ::ecdsa::elliptic_curve::{
-    bigint::Encoding as _, generic_array::GenericArray, sec1, FieldSize, PointCompression,
+    bigint::Integer, generic_array::GenericArray, point::PointCompression, sec1, FieldBytesSize,
     PrimeCurve,
 };
 use serde::{Deserialize, Serialize};
@@ -49,10 +49,9 @@ impl PublicKey {
     pub fn ecdsa<C>(&self) -> Option<sec1::EncodedPoint<C>>
     where
         C: PrimeCurve + CurveAlgorithm + PointCompression,
-        FieldSize<C>: sec1::ModulusSize,
+        FieldBytesSize<C>: sec1::ModulusSize,
     {
-        if self.algorithm != C::asymmetric_algorithm() || self.bytes.len() != C::UInt::BYTE_SIZE * 2
-        {
+        if self.algorithm != C::asymmetric_algorithm() || self.bytes.len() != C::Uint::BYTES * 2 {
             return None;
         }
 

--- a/src/authentication/algorithm.rs
+++ b/src/authentication/algorithm.rs
@@ -3,10 +3,11 @@
 use crate::algorithm;
 
 /// Valid algorithms for auth keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Algorithm {
     /// YubiHSM AES PSK authentication
+    #[default]
     YubicoAes = 0x26,
 }
 
@@ -33,12 +34,6 @@ impl Algorithm {
         match self {
             Algorithm::YubicoAes => 32,
         }
-    }
-}
-
-impl Default for Algorithm {
-    fn default() -> Self {
-        Algorithm::YubicoAes
     }
 }
 

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -5,11 +5,8 @@ use rand_core::{OsRng, RngCore};
 use std::fmt::{self, Debug};
 use zeroize::Zeroize;
 
-#[cfg(feature = "hmac")]
-use hmac::Hmac;
-
 #[cfg(feature = "pbkdf2")]
-use pbkdf2::pbkdf2;
+use pbkdf2::pbkdf2_hmac;
 
 #[cfg(feature = "sha2")]
 use sha2::Sha256;
@@ -50,7 +47,7 @@ impl Key {
     #[cfg_attr(docsrs, doc(cfg(feature = "passwords")))]
     pub fn derive_from_password(password: &[u8]) -> Self {
         let mut kdf_output = [0u8; SIZE];
-        pbkdf2::<Hmac<Sha256>>(password, PBKDF2_SALT, PBKDF2_ITERATIONS, &mut kdf_output);
+        pbkdf2_hmac::<Sha256>(password, PBKDF2_SALT, PBKDF2_ITERATIONS, &mut kdf_output);
         Self::new(kdf_output)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1031,7 +1031,7 @@ impl Client {
         let mut hasher = Sha256::default();
 
         let length = data.len() as u16;
-        hasher.update(&length.to_be_bytes());
+        hasher.update(length.to_be_bytes());
         hasher.update(data);
         let digest = hasher.finalize();
 

--- a/src/ecdsa/secp256k1.rs
+++ b/src/ecdsa/secp256k1.rs
@@ -9,13 +9,10 @@
 //!
 //! It's primarily notable for usage in Bitcoin and other cryptocurrencies.
 
-pub use k256::{ecdsa::recoverable, Secp256k1};
+pub use k256::Secp256k1;
 
 /// ECDSA/secp256k1 signature (fixed-size)
 pub type Signature = super::Signature<Secp256k1>;
-
-/// ECDSA/secp256k1 signature with public key recovery support (ala Ethereum)
-pub type RecoverableSignature = k256::ecdsa::recoverable::Signature;
 
 /// ECDSA/secp256k1 signer
 pub type Signer = super::Signer<Secp256k1>;

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -8,25 +8,24 @@ use ecdsa::{
     elliptic_curve::{
         consts::U32,
         generic_array::ArrayLength,
+        point::PointCompression,
         sec1::{self, FromEncodedPoint, ToEncodedPoint},
-        AffinePoint, FieldSize, PointCompression, PrimeCurve, ProjectiveArithmetic,
+        AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve,
     },
     Signature, SignatureSize, VerifyingKey,
 };
-use signature::{digest::Digest, hazmat::PrehashSigner, DigestSigner, Error, Keypair};
+use signature::{digest::Digest, hazmat::PrehashSigner, DigestSigner, Error, KeypairRef};
 use std::ops::Add;
 
 #[cfg(feature = "secp256k1")]
 use super::Secp256k1;
-#[cfg(feature = "secp256k1")]
-use signature::digest::FixedOutput;
 
 /// ECDSA signature provider for yubihsm-client
 #[derive(signature::Signer)]
 pub struct Signer<C>
 where
-    C: PrimeCurve + CurveAlgorithm + PointCompression + ProjectiveArithmetic,
-    FieldSize<C>: sec1::ModulusSize,
+    C: CurveAlgorithm + CurveArithmetic + PointCompression + PrimeCurve,
+    FieldBytesSize<C>: sec1::ModulusSize,
 {
     /// YubiHSM client.
     client: Client,
@@ -44,9 +43,9 @@ where
 
 impl<C> Signer<C>
 where
-    C: PrimeCurve + CurveAlgorithm + PointCompression + ProjectiveArithmetic,
+    C: CurveAlgorithm + CurveArithmetic + PointCompression + PrimeCurve,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: sec1::ModulusSize,
+    FieldBytesSize<C>: sec1::ModulusSize,
 {
     /// Create a new YubiHSM-backed ECDSA signer
     pub fn create(client: Client, signing_key_id: object::Id) -> Result<Self, Error> {
@@ -73,8 +72,8 @@ where
 
 impl<C> AsRef<VerifyingKey<C>> for Signer<C>
 where
-    C: PrimeCurve + CurveAlgorithm + PointCompression + ProjectiveArithmetic,
-    FieldSize<C>: sec1::ModulusSize,
+    C: CurveAlgorithm + CurveArithmetic + PointCompression + PrimeCurve,
+    FieldBytesSize<C>: sec1::ModulusSize,
 {
     fn as_ref(&self) -> &VerifyingKey<C> {
         &self.verifying_key
@@ -84,19 +83,19 @@ where
 impl<C> From<&Signer<C>> for sec1::EncodedPoint<C>
 where
     Self: Clone,
-    C: PrimeCurve + CurveAlgorithm + PointCompression + ProjectiveArithmetic,
+    C: CurveAlgorithm + CurveArithmetic + PointCompression + PrimeCurve,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: sec1::ModulusSize,
+    FieldBytesSize<C>: sec1::ModulusSize,
 {
     fn from(signer: &Signer<C>) -> sec1::EncodedPoint<C> {
         signer.public_key().clone()
     }
 }
 
-impl<C> Keypair<Signature<C>> for Signer<C>
+impl<C> KeypairRef for Signer<C>
 where
-    C: PrimeCurve + CurveAlgorithm + PointCompression + ProjectiveArithmetic,
-    FieldSize<C>: sec1::ModulusSize,
+    C: CurveAlgorithm + CurveArithmetic + PointCompression + PrimeCurve,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     type VerifyingKey = VerifyingKey<C>;
@@ -104,11 +103,11 @@ where
 
 impl<C> PrehashSigner<Signature<C>> for Signer<C>
 where
-    C: PrimeCurve + CurveAlgorithm + PointCompression + ProjectiveArithmetic,
-    FieldSize<C>: sec1::ModulusSize,
+    C: CurveAlgorithm + CurveArithmetic + PointCompression + PrimeCurve,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
     ecdsa::der::MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<ecdsa::der::MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<ecdsa::der::MaxOverhead> + ArrayLength<u8>,
 {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature<C>, Error> {
         self.client
@@ -150,18 +149,5 @@ where
         // Low-S normalize per BIP 0062: Dealing with Malleability:
         // <https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki>
         Ok(signature.normalize_s().unwrap_or(signature))
-    }
-}
-
-#[cfg(feature = "secp256k1")]
-impl<D> DigestSigner<D, k256::ecdsa::recoverable::Signature> for Signer<Secp256k1>
-where
-    D: Digest<OutputSize = U32> + Clone + Default + FixedOutput,
-{
-    /// Compute an Ethereum-style ECDSA/secp256k1 signature of the given digest
-    fn try_sign_digest(&self, digest: D) -> Result<k256::ecdsa::recoverable::Signature, Error> {
-        let pk = k256::ecdsa::VerifyingKey::from_encoded_point(&self.public_key)?;
-        let sig = self.try_sign_digest(digest.clone())?;
-        k256::ecdsa::recoverable::Signature::from_digest_trial_recovery(&pk, digest, &sig)
     }
 }

--- a/tests/command/decrypt_oaep.rs
+++ b/tests/command/decrypt_oaep.rs
@@ -2,7 +2,6 @@ use crate::{generate_asymmetric_key, TEST_KEY_ID};
 use rand_core;
 use rsa::{self, PublicKey};
 use sha2::{self, Digest};
-
 use yubihsm::{asymmetric, Capability};
 
 /// Test RSA OAEP decryption
@@ -31,11 +30,7 @@ fn rsa_decrypt_oaep_test() {
 
     let mut rng = rand_core::OsRng;
     let ciphertext = rsa_public_key
-        .encrypt(
-            &mut rng,
-            rsa::PaddingScheme::new_oaep::<sha2::Sha256>(),
-            plaintext,
-        )
+        .encrypt(&mut rng, rsa::Oaep::new::<sha2::Sha256>(), plaintext)
         .expect("Failed to encrypt");
 
     let mut hasher = sha2::Sha256::new();

--- a/tests/command/sign_eddsa.rs
+++ b/tests/command/sign_eddsa.rs
@@ -31,7 +31,7 @@ fn test_vectors() {
             .sign_ed25519(TEST_KEY_ID, vector.msg)
             .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
 
-        assert_eq!(signature.as_ref(), vector.sig);
+        assert_eq!(vector.sig, &signature.to_bytes());
     }
 }
 
@@ -57,7 +57,7 @@ fn generated_key_test() {
         .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
 
     assert!(
-        ed25519_dalek::PublicKey::from_bytes(public_key.ed25519().unwrap().as_bytes())
+        ed25519_dalek::VerifyingKey::try_from(public_key.ed25519().unwrap().as_ref())
             .unwrap()
             .verify(TEST_MESSAGE, &signature)
             .is_ok()

--- a/tests/ed25519/mod.rs
+++ b/tests/ed25519/mod.rs
@@ -1,6 +1,6 @@
 //! Ed25519 tests
 
-use ed25519_dalek::{PublicKey, Verifier};
+use ed25519_dalek::{Verifier, VerifyingKey};
 use yubihsm::{asymmetric::signature::Signer as _, ed25519, Client};
 
 /// Key ID to use for test key
@@ -46,6 +46,6 @@ fn ed25519_sign_test() {
     let signer = ed25519::Signer::create(client.clone(), TEST_SIGNING_KEY_ID).unwrap();
     let signature = signer.sign(TEST_MESSAGE);
 
-    let verifier = PublicKey::from_bytes(signer.public_key().as_bytes()).unwrap();
+    let verifier = VerifyingKey::from_bytes(signer.public_key().as_bytes()).unwrap();
     assert!(verifier.verify(TEST_MESSAGE, &signature).is_ok());
 }


### PR DESCRIPTION
Bumps the following dependencies to the latest versions:

- `ecdsa` v0.16
- `ed25519` v2
- `ed25519-dalek` v2.0.0-pre.0
- `k256` v0.13
- `p256` v0.13
- `p384` v0.13
- `pbkdf2` v0.12
- `rsa` v0.9.0-pre.0
- `signature` v2