### PR TITLE
Implement recoverable signatures for ECDSA-Secp256k1

### DIFF
--- a/src/ecdsa/secp256k1.rs
+++ b/src/ecdsa/secp256k1.rs
@@ -14,5 +14,8 @@ pub use k256::Secp256k1;
 /// ECDSA/secp256k1 signature (fixed-size)
 pub type Signature = super::Signature<Secp256k1>;
 
+/// ECDSA/secp256k1 signature recovery id (ala Ethereum)
+pub type RecoveryId = ecdsa::RecoveryId;
+
 /// ECDSA/secp256k1 signer
 pub type Signer = super::Signer<Secp256k1>;

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -12,13 +12,13 @@ use ecdsa::{
         sec1::{self, FromEncodedPoint, ToEncodedPoint},
         AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve,
     },
-    RecoveryId, Signature, SignatureSize, VerifyingKey,
+    Signature, SignatureSize, VerifyingKey,
 };
 use signature::{digest::Digest, hazmat::PrehashSigner, DigestSigner, Error, KeypairRef};
 use std::ops::Add;
 
 #[cfg(feature = "secp256k1")]
-use super::Secp256k1;
+use super::{secp256k1::RecoveryId, Secp256k1};
 
 /// ECDSA signature provider for yubihsm-client
 #[derive(signature::Signer)]


### PR DESCRIPTION
Implement recoverable signatures for ECDSA-Secp256k1 signer and make `PrehashSigner<Signature<Secp256k1>>` return normalized `s` values.

No recoverable [`signature::Signer`](https://docs.rs/signature/latest/signature/trait.Signer.html) implementation for [`yubihsm::ecdsa::Signer`](https://docs.rs/yubihsm/latest/yubihsm/ecdsa/struct.Signer.html) since we can't implement [`signature::PrehashSignature`](https://docs.rs/signature/latest/signature/trait.PrehashSignature.html) for `(Signature<Secp256k1>, RecoveryId)`.

There is a bit of a repetition now with the `P-256` and `P-384` implementations -- I could add a macro for them.

Related: https://github.com/gakonst/ethers-rs/issues/2158, https://github.com/gakonst/ethers-rs/pull/2260