### PR TITLE
audit: Adds support for HSM initialization entry

### DIFF
--- a/src/audit/commands/get_log_entries.rs
+++ b/src/audit/commands/get_log_entries.rs
@@ -39,7 +39,7 @@ impl Response for LogEntries {
 }
 
 /// Entry in the log response
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct LogEntry {
     /// Entry number
     pub item: u16,
@@ -73,7 +73,7 @@ pub struct LogEntry {
 pub const LOG_DIGEST_SIZE: usize = 16;
 
 /// Truncated SHA-256 digest of a log entry and the previous log digest
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct LogDigest(pub [u8; LOG_DIGEST_SIZE]);
 
 impl AsRef<[u8]> for LogDigest {
@@ -90,5 +90,38 @@ impl Debug for LogDigest {
             write!(f, "{}", if i == LOG_DIGEST_SIZE - 1 { ")" } else { ":" })?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serialization::deserialize;
+
+    static SAMPLE_ENTRY: &[u8] = &[
+        0, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 237, 217, 180,
+        224, 195, 140, 79, 126, 197, 15, 5, 112, 145, 241, 47, 206,
+    ];
+
+    #[test]
+    fn test_get_log_entry() {
+        let entry: LogEntry = deserialize(SAMPLE_ENTRY).expect("Parse log entry");
+        assert_eq!(
+            entry,
+            LogEntry {
+                item: 1,
+                cmd: command::Code::HsmInitialization,
+                length: 65535,
+                session_key: 65535,
+                target_key: 65535,
+                second_key: 65535,
+                result: response::Code::Success(command::Code::Error),
+                tick: 4294967295,
+                digest: LogDigest([
+                    0xed, 0xd9, 0xb4, 0xe0, 0xc3, 0x8c, 0x4f, 0x7e, 0xc5, 0x0f, 0x05, 0x70, 0x91,
+                    0xf1, 0x2f, 0xce
+                ])
+            }
+        )
     }
 }

--- a/src/command/code.rs
+++ b/src/command/code.rs
@@ -63,6 +63,7 @@ pub enum Code {
     BlinkDevice = 0x6b,
     ChangeAuthenticationKey = 0x6c,
     Error = 0x7f,
+    HsmInitialization = 0xff,
 }
 
 impl Code {
@@ -124,6 +125,7 @@ impl Code {
             0x6b => Code::BlinkDevice,
             0x6c => Code::ChangeAuthenticationKey,
             0x7f => Code::Error,
+            0xff => Code::HsmInitialization,
             _ => fail!(ErrorKind::CodeInvalid, "invalid command type: {}", byte),
         })
     }


### PR DESCRIPTION
When command audit is enabled at HSM initialization, an "invalid" entry is present which would fail the deserialization and leave empty entries. Because the entries are left empty, the log-index can't be bumped.

This adds support for deserialization of those entries.