### PR TITLE
handle closed yubihsm-connector connection

### DIFF
--- a/src/connector/http/client/response/reader.rs
+++ b/src/connector/http/client/response/reader.rs
@@ -61,6 +61,18 @@ impl Reader {
     fn fill_buffer(&mut self, readable: &mut dyn Read) -> Result<usize, Error> {
         let nbytes = readable.read(self.buffer.as_mut())?;
         self.pos += nbytes;
+
+        // See: https://doc.rust-lang.org/src/std/io/mod.rs.html#571
+        // On Linux, read method will call the recv syscall for a TcpStream,
+        // where returning zero indicates the connection was shut down correctly
+        if nbytes == 0 {
+            fail!(
+                ResponseError,
+                "read {} bytes, the remote connection was likely shutdown",
+                nbytes
+            );
+        }
+
         Ok(nbytes)
     }
 


### PR DESCRIPTION
# TL;DR
When yubihsm-connector is restarted / shutdown the yubihsm.rs http client enters infinite condition, and busy loops, eating up 100% of CPU time.

![image](https://github.com/iqlusioninc/yubihsm.rs/assets/4912567/4acf0515-6144-4c58-9ce2-1ffb4bee9367)

## How to repro?
Components: TMKMS (v0.12.2) and yubihsm-connector (2021-03-ubuntu1804-amd64) + osmosis testnet node (can be any other cosmos-sdk network)

### Setup A: Both tmkms and yubihsm-connector run on the same machine
In this setup it's hard to reproduce. I am not sure why, but out of many tries, I managed to break tmkms/yubihsm.rs only once.

### Setup B: tmkms + osmosis node run on host A, where yubihsm-connector with HSM device run on host B
In this setup I can reproduce the issue every single time.

### Flow
1. Start TMKMS + Osmosis node and observe tmkms logs to see signed votes
2. Restart yubihsm-connector (or shut it down and start again, or don't start at all)
3. Observe TMKMS logs, see the last log line:
```
Jun 28 18:32:47 <host A> tmkms[1349138]: 2023-06-28T18:32:47.623775Z DEBUG yubihsm::session: session=5 n=1147 uuid=dccf03d4-34bd-4156-af7b-352fbdeeb75d cmd=SignEddsa
```
4. Check CPU usage with TOP/HTOP and confirm the ~100% usage
5. Restart TMKMS and see it works again

# FIX
The patch simply checks if socket returned 0 bytes and errors out if it did. Based on the Rust documentation 0 bytes indicates closed connection, in case of TcpStream, and that is precisely the case here. Yubihsm.rs uses TcpStream to transport HTTP messages.

Quote from [docs](https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read):
```
Pull some bytes from this source into the specified buffer, returning how many bytes were read.

This function does not provide any guarantees about whether it blocks waiting for data, but if an object needs to block for a read and cannot, it will typically signal this via an [Err](https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err) return value.

If the return value of this method is [Ok(n)](https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok), then implementations must guarantee that 0 <= n <= buf.len(). A nonzero n value indicates that the buffer buf has been filled in with n bytes of data from this source. If n is 0, then it can indicate one of two scenarios:
1. This reader has reached its “end of file” and will likely no longer be able to produce bytes. Note that this does not mean that the reader will always no longer be able to produce bytes. As an example, on Linux, this method will call the recv syscall for a [TcpStream](https://doc.rust-lang.org/std/net/struct.TcpStream.html), where returning zero indicates the connection was shut down correctly. While for [File](https://doc.rust-lang.org/std/fs/struct.File.html), it is possible to reach the end of file and get zero as result, but if more data is appended to the file, future calls to read will return more data.
2. The buffer specified was 0 bytes in length.
```

# Test plan
I did reproduce the faulty flow with the patched binary and I could see the message:
```
Jun 29 22:38:32 <host A> tmkms[2888484]: 2023-06-29T22:38:32.272595Z ERROR tmkms::client: [...] signing operation failed: signature error: protocol error: protocol error: bad response from connector: error reading response
```

after that tmkms moves on and signs the further messages.

Unittests:
```
$ cargo test
test result: ok. 29 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 22.70s

$ cargo test --features=usb
test result: ok. 29 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 33.73s

$ cargo test --features=mockhsm
test result: ok. 27 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.61s
```

# Why is this important?
Without the patch, every time the yubihsm-connector is restarted, the tmkms gets stuck. This may happen rarely on the localhost, but occurs 100% of the time in the remote setup.