### PR TITLE
Enable parsing of the initial log entry & use of log entry types.

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -5,6 +5,9 @@ mod error;
 
 pub use self::error::{Error, ErrorKind};
 
+mod log;
+pub use self::log::{LogEntries, LogEntry};
+
 use crate::command;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;

--- a/src/audit/commands/get_log_entries.rs
+++ b/src/audit/commands/get_log_entries.rs
@@ -2,13 +2,9 @@
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/Get_Log_Entries.html>
 
-use crate::{
-    command::{self, Command},
-    object,
-    response::{self, Response},
-};
+use crate::{audit::log::LogEntries, command::Command};
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Debug};
+use std::fmt::Debug;
 
 /// Request parameters for `command::get_log_entries`
 #[derive(Serialize, Deserialize, Debug)]
@@ -16,79 +12,4 @@ pub(crate) struct GetLogEntriesCommand {}
 
 impl Command for GetLogEntriesCommand {
     type ResponseType = LogEntries;
-}
-
-/// Response from `command::get_log_entries`
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LogEntries {
-    /// Number of boot events which weren't logged (if buffer is full and audit enforce is set)
-    pub unlogged_boot_events: u16,
-
-    /// Number of unlogged authentication events (if buffer is full and audit enforce is set)
-    pub unlogged_auth_events: u16,
-
-    /// Number of entries in the response
-    pub num_entries: u8,
-
-    /// Entries in the log
-    pub entries: Vec<LogEntry>,
-}
-
-impl Response for LogEntries {
-    const COMMAND_CODE: command::Code = command::Code::GetLogEntries;
-}
-
-/// Entry in the log response
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LogEntry {
-    /// Entry number
-    pub item: u16,
-
-    /// Command type
-    pub cmd: command::Code,
-
-    /// Command length
-    pub length: u16,
-
-    /// Session key ID
-    pub session_key: object::Id,
-
-    /// Target key ID
-    pub target_key: object::Id,
-
-    /// Second key affected
-    pub second_key: object::Id,
-
-    /// Result of the operation
-    pub result: response::Code,
-
-    /// Tick count of the HSM's internal clock
-    pub tick: u32,
-
-    /// 16-byte truncated SHA-256 digest of this log entry and the digest of the previous entry
-    pub digest: LogDigest,
-}
-
-/// Size of a truncated digest in the log
-pub const LOG_DIGEST_SIZE: usize = 16;
-
-/// Truncated SHA-256 digest of a log entry and the previous log digest
-#[derive(Serialize, Deserialize)]
-pub struct LogDigest(pub [u8; LOG_DIGEST_SIZE]);
-
-impl AsRef<[u8]> for LogDigest {
-    fn as_ref(&self) -> &[u8] {
-        &self.0[..]
-    }
-}
-
-impl Debug for LogDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LogDigest(")?;
-        for (i, byte) in self.0.iter().enumerate() {
-            write!(f, "{:02x}", byte)?;
-            write!(f, "{}", if i == LOG_DIGEST_SIZE - 1 { ")" } else { ":" })?;
-        }
-        Ok(())
-    }
 }

--- a/src/audit/log.rs
+++ b/src/audit/log.rs
@@ -79,3 +79,57 @@ impl Debug for LogDigest {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serialization::{deserialize, serialize};
+    use std::{error, result};
+
+    type Result<T> = result::Result<T, Box<dyn error::Error>>;
+
+    #[rustfmt::skip]
+    const INITIAL_LOG_ENTRY_BUF: [u8; 32] = [
+        0, 1, // item
+        255, // cmd
+        255, 255, // length
+        255, 255, // session key
+        255, 255, // target key
+        255, 255, // second key
+        255, // result
+        255, 255, 255, 255, // tick
+        // half digest
+        255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255,
+    ];
+
+    const INITIAL_LOG_ENTRY: LogEntry = LogEntry {
+        item: 1u16,
+        cmd: command::Code::InitialLogEntry,
+        length: u16::MAX,
+        session_key: object::Id::MAX,
+        target_key: object::Id::MAX,
+        second_key: object::Id::MAX,
+        result: response::Code::Success(command::Code::InitialLogEntry),
+        tick: u32::MAX,
+        #[rustfmt::skip]
+        digest: LogDigest([
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255,
+        ]),
+    };
+
+    #[test]
+    fn initial_log_entry_deserialize() -> Result<()> {
+        let result: LogEntry = deserialize(&INITIAL_LOG_ENTRY_BUF)?;
+        assert_eq!(result, INITIAL_LOG_ENTRY);
+        Ok(())
+    }
+
+    #[test]
+    fn initial_log_entry_serialize() -> Result<()> {
+        let result = serialize(&INITIAL_LOG_ENTRY)?;
+        assert_eq!(result, INITIAL_LOG_ENTRY_BUF);
+        Ok(())
+    }
+}

--- a/src/audit/log.rs
+++ b/src/audit/log.rs
@@ -1,0 +1,81 @@
+use crate::{
+    command, object,
+    response::{self, Response},
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug};
+
+/// Response from `command::get_log_entries`
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct LogEntries {
+    /// Number of boot events which weren't logged (if buffer is full and audit enforce is set)
+    pub unlogged_boot_events: u16,
+
+    /// Number of unlogged authentication events (if buffer is full and audit enforce is set)
+    pub unlogged_auth_events: u16,
+
+    /// Number of entries in the response
+    pub num_entries: u8,
+
+    /// Entries in the log
+    pub entries: Vec<LogEntry>,
+}
+
+impl Response for LogEntries {
+    const COMMAND_CODE: command::Code = command::Code::GetLogEntries;
+}
+
+/// Entry in the log response
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct LogEntry {
+    /// Entry number
+    pub item: u16,
+
+    /// Command type
+    pub cmd: command::Code,
+
+    /// Command length
+    pub length: u16,
+
+    /// Session key ID
+    pub session_key: object::Id,
+
+    /// Target key ID
+    pub target_key: object::Id,
+
+    /// Second key affected
+    pub second_key: object::Id,
+
+    /// Result of the operation
+    pub result: response::Code,
+
+    /// Tick count of the HSM's internal clock
+    pub tick: u32,
+
+    /// 16-byte truncated SHA-256 digest of this log entry and the digest of the previous entry
+    pub digest: LogDigest,
+}
+
+/// Size of a truncated digest in the log
+pub const LOG_DIGEST_SIZE: usize = 16;
+
+/// Truncated SHA-256 digest of a log entry and the previous log digest
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct LogDigest(pub [u8; LOG_DIGEST_SIZE]);
+
+impl AsRef<[u8]> for LogDigest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl Debug for LogDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LogDigest(")?;
+        for (i, byte) in self.0.iter().enumerate() {
+            write!(f, "{:02x}", byte)?;
+            write!(f, "{}", if i == LOG_DIGEST_SIZE - 1 { ")" } else { ":" })?;
+        }
+        Ok(())
+    }
+}

--- a/src/command/code.rs
+++ b/src/command/code.rs
@@ -63,6 +63,7 @@ pub enum Code {
     BlinkDevice = 0x6b,
     ChangeAuthenticationKey = 0x6c,
     Error = 0x7f,
+    InitialLogEntry = 0xff,
 }
 
 impl Code {
@@ -124,6 +125,7 @@ impl Code {
             0x6b => Code::BlinkDevice,
             0x6c => Code::ChangeAuthenticationKey,
             0x7f => Code::Error,
+            0xff => Code::InitialLogEntry,
             _ => fail!(ErrorKind::CodeInvalid, "invalid command type: {}", byte),
         })
     }

--- a/src/response/code.rs
+++ b/src/response/code.rs
@@ -104,6 +104,11 @@ pub enum Code {
 impl Code {
     /// Convert an unsigned byte into a Code (if valid)
     pub fn from_u8(byte: u8) -> Result<Self, Error> {
+        // InitialLogEntry is a special case: it is not offset by 0x80
+        if byte == command::Code::InitialLogEntry.to_u8() {
+            return Ok(Code::Success(command::Code::InitialLogEntry));
+        }
+
         let code = i16::from(byte).checked_sub(0x80).unwrap() as i8;
 
         Ok(match code {
@@ -147,6 +152,10 @@ impl Code {
 
     /// Convert a Code back into its original byte form
     pub fn to_u8(self) -> u8 {
+        // InitialLogEntry is a special case: it is not offset by 0x80
+        if self == Code::Success(command::Code::InitialLogEntry) {
+            return command::Code::InitialLogEntry.to_u8();
+        }
         let code: i8 = match self {
             Code::Success(cmd_type) => cmd_type as i8,
             Code::MemoryError => -1,


### PR DESCRIPTION
The current implementation will return an empty `LogEntries` structure if `get_log_entries` returns a `LogEntries` that contains an initial `LogEntry`. AFAIK this is caused by a failure to parse / deserialize the `cmd` field of the `LogEntry` when it's set to `255` as this doesn't currently map to a `command::Code`. The initial log entry is described in https://developers.yubico.com/YubiHSM2/Commands/Get_Log_Entries.html

This PR does 2 things:
- Move the `LogEntries` and `LogEntry` structure out of the `audit::commands` module (`pub(crate)` visibility) to the `audit` module where they're given `pub` visibility to allow use of these types by external code.
- Update `from_u8` and `to_u8` in `response::Code` to map the value for the initial log entry value from the `LogEntry::cmd` field.