### PR TITLE
Cargo.lock: update dependencies; MSRV 1.67

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.67.0 # MSRV
+          toolchain: 1.71.0 # pinned to prevent CI breakages
           components: clippy
           override: true
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.65.0 # MSRV
+          - 1.67.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -56,7 +56,7 @@ jobs:
           - macos-latest
         toolchain:
           - stable
-          - 1.65.0 # MSRV
+          - 1.67.0 # MSRV
     steps:
       - uses: actions/checkout@v1
       - name: cache .cargo/registry
@@ -100,7 +100,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0 # MSRV
+          toolchain: 1.67.0 # MSRV
           components: clippy
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -43,30 +43,30 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
-version = "2.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -88,9 +88,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ccm"
@@ -112,15 +115,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chunked_transfer"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -139,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "cpufeatures"
@@ -154,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071c0f5945634bc9ba7a452f492377dd6b1993665ddb58f28704119b32f07a9a"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -209,7 +212,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn",
 ]
 
 [[package]]
@@ -223,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.2"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c5cb402c5c958281c7c0702edea7b780d03b86b606497ca3a10fcd3fc393ac"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -233,10 +236,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.6"
+name = "deranged"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -246,22 +258,23 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der",
  "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
 dependencies = [
  "pkcs8",
  "signature",
@@ -283,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cdacd4d6ed3f9b98680b679c0e52a823b8a2c7a97358d508fe247f2180c282"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -313,15 +326,15 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -330,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -361,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "inout"
@@ -377,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "k256"
@@ -406,15 +419,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libusb1-sys"
@@ -430,18 +443,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -477,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -487,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "p256"
@@ -517,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
@@ -557,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platforms"
@@ -575,9 +585,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
+checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
 dependencies = [
  "elliptic-curve",
 ]
@@ -593,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -641,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f1471dbb4be5de45050e8ef7040625298ccb9efe941419ac2697088715925f"
+checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
 dependencies = [
  "byteorder",
  "const-oid",
@@ -656,6 +666,7 @@ dependencies = [
  "pkcs8",
  "rand_core",
  "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -681,15 +692,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sec1"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -707,29 +718,29 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.104",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -738,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -760,20 +771,20 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede930749cca4e3a3df7e37b5f0934a55693e01d028d7a4e506b44cbc059d95a"
+checksum = "acdf373908a51854e3c302a3cad677fadcf719255d4d3bd844405e379e9415fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.104",
+ "syn",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "spin"
@@ -783,9 +794,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der",
@@ -793,70 +804,48 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.104",
- "unicode-xid",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "serde",
  "time-core",
  "time-macros",
@@ -864,15 +853,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -891,27 +880,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "serde",
 ]
@@ -980,12 +963,11 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.104",
- "synstructure",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 categories = ["cryptography", "hardware-support"]
 keywords = ["ecdsa", "ed25519", "hmac", "hsm", "yubikey"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.67"
 
 [dependencies]
 aes = "0.8"

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [crate-link]: https://crates.io/crates/yubihsm
 [docs-image]: https://docs.rs/yubihsm/badge.svg
 [docs-link]: https://docs.rs/yubihsm/
-[build-image]: https://github.com/iqlusioninc/yubihsm.rs/workflows/CI/badge.svg?branch=main&event=push
-[build-link]: https://github.com/iqlusioninc/yubihsm.rs/actions?query=workflow:CI
+[build-image]: https://github.com/iqlusioninc/yubihsm.rs/actions/workflows/ci.yml/badge.svg
+[build-link]: https://github.com/iqlusioninc/yubihsm.rs/actions/workflows/ci.yml
 [deps-image]: https://deps.rs/repo/github/iqlusioninc/yubihsm.rs/status.svg
 [deps-link]: https://deps.rs/repo/github/iqlusioninc/yubihsm.rs
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.67+-blue.svg
 
 [//]: # (general links)
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -133,12 +133,12 @@ impl<'de> Deserialize<'de> for AuditTag {
             }
 
             fn visit_u8<E: de::Error>(self, value: u8) -> Result<AuditTag, E> {
-                AuditTag::from_u8(value).map_err(|e| E::custom(format!("{}", e)))
+                AuditTag::from_u8(value).map_err(|e| E::custom(format!("{e}")))
             }
 
             fn visit_u64<E: de::Error>(self, value: u64) -> Result<AuditTag, E> {
                 assert!(value < 255);
-                AuditTag::from_u8(value as u8).map_err(|e| E::custom(format!("{}", e)))
+                AuditTag::from_u8(value as u8).map_err(|e| E::custom(format!("{e}")))
             }
         }
 

--- a/src/audit/commands/get_log_entries.rs
+++ b/src/audit/commands/get_log_entries.rs
@@ -86,7 +86,7 @@ impl Debug for LogDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "LogDigest(")?;
         for (i, byte) in self.0.iter().enumerate() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
             write!(f, "{}", if i == LOG_DIGEST_SIZE - 1 { ")" } else { ":" })?;
         }
         Ok(())

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -270,7 +270,7 @@ impl Display for Capability {
             _ => return Err(fmt::Error), // we don't support displaying this capability yet
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/src/connector/http/client/connection.rs
+++ b/src/connector/http/client/connection.rs
@@ -41,7 +41,7 @@ pub struct Connection {
 impl Connection {
     /// Create a new connection to an HTTP server
     pub fn open(addr: &str, port: u16, opts: &ConnectionOptions) -> Result<Self, Error> {
-        let host = format!("{}:{}", addr, port);
+        let host = format!("{addr}:{port}");
 
         let socketaddr = &host.to_socket_addrs()?.next().ok_or_else(|| {
             err!(
@@ -71,9 +71,9 @@ impl Connection {
         let path = into_path.into();
         let mut headers = String::new();
 
-        writeln!(headers, "POST {} {}\r", path, HTTP_VERSION)?;
+        writeln!(headers, "POST {path} {HTTP_VERSION}\r")?;
         writeln!(headers, "Host: {}\r", self.host)?;
-        writeln!(headers, "User-Agent: {}\r", USER_AGENT)?;
+        writeln!(headers, "User-Agent: {USER_AGENT}\r")?;
         writeln!(headers, "Content-Length: {}\r", body.0.len())?;
         writeln!(headers, "\r")?;
 

--- a/src/connector/http/client/error.rs
+++ b/src/connector/http/client/error.rs
@@ -79,7 +79,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::ResponseError => "error reading response",
         };
 
-        write!(f, "{}", description)
+        write!(f, "{description}")
     }
 }
 

--- a/src/connector/usb/device.rs
+++ b/src/connector/usb/device.rs
@@ -113,7 +113,7 @@ impl Devices {
             let t = timeout.duration();
             let manufacturer = handle.read_manufacturer_string(language, &desc, t)?;
             let product = handle.read_product_string(language, &desc, t)?;
-            let product_name = format!("{} {}", manufacturer, product);
+            let product_name = format!("{manufacturer} {product}");
             let serial_number: SerialNumber = handle
                 .read_serial_number_string(language, &desc, t)?
                 .parse()

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ where
         write!(f, "{}", &self.kind)?;
 
         if let Some(ref source) = self.source {
-            write!(f, ": {}", source)?;
+            write!(f, ": {source}")?;
         }
 
         Ok(())

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -41,7 +41,7 @@ pub(crate) fn create_session(
     cmd_message: &Message,
 ) -> Result<Vec<u8>, connector::Error> {
     let cmd: CreateSessionCommand = deserialize(cmd_message.data.as_ref())
-        .unwrap_or_else(|e| panic!("error parsing CreateSession command data: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing CreateSession command data: {e:?}"));
 
     let session = state.create_session(cmd.authentication_key_id, cmd.host_challenge);
 
@@ -119,7 +119,7 @@ pub(crate) fn session_message(
         Code::SignEddsa => sign_eddsa(state, &command.data),
         Code::GetStorageInfo => get_storage_info(),
         Code::VerifyHmac => verify_hmac(state, &command.data),
-        unsupported => panic!("unsupported command type: {:?}", unsupported),
+        unsupported => panic!("unsupported command type: {unsupported:?}"),
     };
 
     Ok(state
@@ -140,8 +140,8 @@ fn close_session(state: &mut State, session_id: session::Id) -> Result<Vec<u8>, 
 
 /// Delete an object
 fn delete_object(state: &mut State, cmd_data: &[u8]) -> response::Message {
-    let command: DeleteObjectCommand = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::DeleteObject: {:?}", e));
+    let command: DeleteObjectCommand =
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::DeleteObject: {e:?}"));
 
     if state
         .objects
@@ -230,7 +230,7 @@ fn export_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
         object_type,
         object_id,
     } = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::ExportWrapped: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::ExportWrapped: {e:?}"));
 
     let nonce = wrap::Nonce::generate();
 
@@ -249,7 +249,7 @@ fn export_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
 /// Generate a new random asymmetric key
 fn gen_asymmetric_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let GenAsymmetricKeyCommand(command) = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::GenAsymmetricKey: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::GenAsymmetricKey: {e:?}"));
 
     state.objects.generate(
         command.key_id,
@@ -270,7 +270,7 @@ fn gen_asymmetric_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
 /// Generate a new random HMAC key
 fn gen_hmac_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let GenHmacKeyCommand(command) =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::GenHMACKey: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::GenHMACKey: {e:?}"));
 
     state.objects.generate(
         command.key_id,
@@ -293,7 +293,7 @@ fn gen_wrap_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let GenWrapKeyCommand {
         params,
         delegated_capabilities,
-    } = deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::GenWrapKey: {:?}", e));
+    } = deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::GenWrapKey: {e:?}"));
 
     state.objects.generate(
         params.key_id,
@@ -326,7 +326,7 @@ fn get_log_entries() -> response::Message {
 /// Get detailed info about a specific object
 fn get_object_info(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: GetObjectInfoCommand = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::GetObjectInfo: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::GetObjectInfo: {e:?}"));
 
     if let Some(obj) = state
         .objects
@@ -342,7 +342,7 @@ fn get_object_info(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Get an opaque object (X.509 certificate or other data) stored in the HSM
 fn get_opaque(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: GetOpaqueCommand = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::GetOpaqueObject: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::GetOpaqueObject: {e:?}"));
 
     if let Some(obj) = state.objects.get(command.object_id, object::Type::Opaque) {
         GetOpaqueResponse(obj.payload.to_bytes()).serialize()
@@ -355,7 +355,7 @@ fn get_opaque(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Get an auditing option
 fn get_option(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: GetOptionCommand = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::GetOpaqueObject: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::GetOpaqueObject: {e:?}"));
 
     let results = match command.tag {
         AuditTag::Command => state.command_audit_options.serialize(),
@@ -368,7 +368,7 @@ fn get_option(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Get bytes of random data
 fn get_pseudo_random(_state: &State, cmd_data: &[u8]) -> response::Message {
     let command: GetPseudoRandomCommand = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::GetPseudoRandom: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::GetPseudoRandom: {e:?}"));
 
     let mut bytes = vec![0u8; command.bytes as usize];
     OsRng.fill_bytes(&mut bytes);
@@ -379,7 +379,7 @@ fn get_pseudo_random(_state: &State, cmd_data: &[u8]) -> response::Message {
 /// Get the public key associated with a key in the HSM
 fn get_public_key(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: GetPublicKeyCommand =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::GetPubKey: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::GetPubKey: {e:?}"));
 
     if let Some(obj) = state
         .objects
@@ -417,7 +417,7 @@ fn import_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
         nonce,
         ciphertext,
     } = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::ImportWrapped: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::ImportWrapped: {e:?}"));
 
     match state.objects.unwrap_obj(wrap_key_id, &nonce, ciphertext) {
         Ok(obj) => ImportWrappedResponse {
@@ -434,8 +434,8 @@ fn import_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
 
 /// List all objects presently accessible to a session
 fn list_objects(state: &State, cmd_data: &[u8]) -> response::Message {
-    let command: ListObjectsCommand = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::ListObjects: {:?}", e));
+    let command: ListObjectsCommand =
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::ListObjects: {e:?}"));
 
     let len = command.0.len() as u64;
     let mut cursor = Cursor::new(command.0);
@@ -473,7 +473,7 @@ fn list_objects(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Put an existing asymmetric key into the HSM
 fn put_asymmetric_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let PutAsymmetricKeyCommand { params, data } = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::PutAsymmetricKey: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::PutAsymmetricKey: {e:?}"));
 
     state.objects.put(
         params.id,
@@ -496,7 +496,7 @@ fn put_authentication_key(state: &mut State, cmd_data: &[u8]) -> response::Messa
         delegated_capabilities,
         authentication_key,
     } = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::PutAuthenticationKey: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::PutAuthenticationKey: {e:?}"));
 
     state.objects.put(
         params.id,
@@ -515,7 +515,7 @@ fn put_authentication_key(state: &mut State, cmd_data: &[u8]) -> response::Messa
 /// Put a new HMAC key into the HSM
 fn put_hmac_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let PutHmacKeyCommand { params, hmac_key } =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::PutHMACKey: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::PutHMACKey: {e:?}"));
 
     state.objects.put(
         params.id,
@@ -534,7 +534,7 @@ fn put_hmac_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
 /// Put an opaque object (X.509 cert or other data) into the HSM
 fn put_opaque(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let PutOpaqueCommand { params, data } = deserialize(cmd_data)
-        .unwrap_or_else(|e| panic!("error parsing Code::PutOpaqueObject: {:?}", e));
+        .unwrap_or_else(|e| panic!("error parsing Code::PutOpaqueObject: {e:?}"));
 
     state.objects.put(
         params.id,
@@ -556,7 +556,7 @@ fn put_opaque(state: &mut State, cmd_data: &[u8]) -> response::Message {
 /// Change an HSM auditing setting
 fn put_option(state: &mut State, cmd_data: &[u8]) -> response::Message {
     let SetOptionCommand { tag, length, value } =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::PutOption: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::PutOption: {e:?}"));
 
     match tag {
         AuditTag::Force => {
@@ -565,8 +565,8 @@ fn put_option(state: &mut State, cmd_data: &[u8]) -> response::Message {
         }
         AuditTag::Command => {
             assert_eq!(length, 2);
-            let audit_cmd: AuditCommand = deserialize(&value)
-                .unwrap_or_else(|e| panic!("error parsing AuditCommand: {:?}", e));
+            let audit_cmd: AuditCommand =
+                deserialize(&value).unwrap_or_else(|e| panic!("error parsing AuditCommand: {e:?}"));
 
             state
                 .command_audit_options
@@ -583,7 +583,7 @@ fn put_wrap_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
         params,
         delegated_capabilities,
         data,
-    } = deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::PutWrapKey: {:?}", e));
+    } = deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::PutWrapKey: {e:?}"));
 
     state.objects.put(
         params.id,
@@ -614,7 +614,7 @@ fn reset_device(state: &mut State, session_id: session::Id) -> Vec<u8> {
 /// Sign a message using the ECDSA signature algorithm
 fn sign_ecdsa(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: SignEcdsaCommand =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::SignEcdsa: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::SignEcdsa: {e:?}"));
 
     if let Some(obj) = state
         .objects
@@ -661,7 +661,7 @@ fn sign_ecdsa(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Sign a message using the Ed25519 signature algorithm
 fn sign_eddsa(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: SignEddsaCommand =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::SignEdDSA: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::SignEdDSA: {e:?}"));
 
     if let Some(obj) = state
         .objects
@@ -683,7 +683,7 @@ fn sign_eddsa(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Compute the HMAC tag for the given data
 fn sign_hmac(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: SignHmacCommand =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::HMACData: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::HMACData: {e:?}"));
 
     if let Some(obj) = state.objects.get(command.key_id, object::Type::HmacKey) {
         if let Payload::HmacKey(alg, ref key) = obj.payload {
@@ -705,7 +705,7 @@ fn sign_hmac(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Verify the HMAC tag for the given data
 fn verify_hmac(state: &State, cmd_data: &[u8]) -> response::Message {
     let command: VerifyHmacCommand =
-        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::HMACData: {:?}", e));
+        deserialize(cmd_data).unwrap_or_else(|e| panic!("error parsing Code::HMACData: {e:?}"));
 
     if let Some(obj) = state.objects.get(command.key_id, object::Type::HmacKey) {
         if let Payload::HmacKey(alg, ref key) = obj.payload {

--- a/src/mockhsm/object/payload.rs
+++ b/src/mockhsm/object/payload.rs
@@ -49,17 +49,16 @@ impl Payload {
                     assert_eq!(data.len(), ed25519::SECRET_KEY_LENGTH);
                     Payload::Ed25519Key(ed25519::SigningKey::try_from(data).unwrap())
                 }
-                _ => panic!(
-                    "MockHsm doesn't support this asymmetric algorithm: {:?}",
-                    asymmetric_alg
-                ),
+                _ => {
+                    panic!("MockHsm doesn't support this asymmetric algorithm: {asymmetric_alg:?}")
+                }
             },
             Algorithm::Hmac(alg) => Payload::HmacKey(alg, data.into()),
             Algorithm::Opaque(alg) => Payload::Opaque(alg, data.into()),
             Algorithm::Authentication(_) => {
                 Payload::AuthenticationKey(authentication::Key::from_slice(data).unwrap())
             }
-            _ => panic!("MockHsm does not support putting {:?} objects", algorithm),
+            _ => panic!("MockHsm does not support putting {algorithm:?} objects"),
         }
     }
 
@@ -81,20 +80,16 @@ impl Payload {
                 asymmetric::Algorithm::Ed25519 => {
                     Payload::Ed25519Key(ed25519::SigningKey::generate(&mut OsRng))
                 }
-                _ => panic!(
-                    "MockHsm doesn't support this asymmetric algorithm: {:?}",
-                    asymmetric_alg
-                ),
+                _ => {
+                    panic!("MockHsm doesn't support this asymmetric algorithm: {asymmetric_alg:?}")
+                }
             },
             Algorithm::Hmac(hmac_alg) => {
                 let mut bytes = vec![0u8; hmac_alg.key_len()];
                 OsRng.fill_bytes(&mut bytes);
                 Payload::HmacKey(hmac_alg, bytes)
             }
-            _ => panic!(
-                "MockHsm does not support generating {:?} objects",
-                algorithm
-            ),
+            _ => panic!("MockHsm does not support generating {algorithm:?} objects"),
         }
     }
 

--- a/src/mockhsm/state.rs
+++ b/src/mockhsm/state.rs
@@ -61,10 +61,7 @@ impl State {
                 .objects
                 .get(authentication_key_id, object::Type::AuthenticationKey)
                 .unwrap_or_else(|| {
-                    panic!(
-                        "MockHsm has no authentication::Key in slot {:?}",
-                        authentication_key_id
-                    )
+                    panic!("MockHsm has no authentication::Key in slot {authentication_key_id:?}")
                 });
 
             SecureChannel::new(

--- a/src/session/securechannel/kdf.rs
+++ b/src/session/securechannel/kdf.rs
@@ -13,8 +13,7 @@ pub fn derive(mac_key: &[u8], derivation_constant: u8, context: &Context, output
     let output_len = output.len();
     assert!(
         output_len <= 16,
-        "up to 16-bytes of data supported ({} requested)",
-        output_len
+        "up to 16-bytes of data supported ({output_len} requested)"
     );
 
     let mut derivation_data = [0u8; 32];

--- a/tests/command/device_info.rs
+++ b/tests/command/device_info.rs
@@ -5,7 +5,7 @@ fn device_info_test() {
 
     let device_info = client
         .device_info()
-        .unwrap_or_else(|err| panic!("error getting device info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting device info: {err}"));
 
     // This should always be 2. The minor and patch versions will vary
     // depending on the specific YubiHSM 2 model.

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -25,7 +25,7 @@ fn wrap_key_test() {
             algorithm,
             AESCCM_TEST_VECTORS[0].key,
         )
-        .unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
+        .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 
     assert_eq!(key_id, TEST_KEY_ID);
 
@@ -44,11 +44,11 @@ fn wrap_key_test() {
             exported_key_capabilities,
             exported_key_algorithm,
         )
-        .unwrap_or_else(|err| panic!("error generating asymmetric key: {}", err));
+        .unwrap_or_else(|err| panic!("error generating asymmetric key: {err}"));
 
     let wrap_data = client
         .export_wrapped(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
-        .unwrap_or_else(|err| panic!("error exporting key: {}", err));
+        .unwrap_or_else(|err| panic!("error exporting key: {err}"));
 
     // Delete the object from the HSM prior to re-importing it
     assert!(client
@@ -58,14 +58,14 @@ fn wrap_key_test() {
     // Re-import the wrapped key back into the HSM
     let import_response = client
         .import_wrapped(TEST_KEY_ID, wrap_data)
-        .unwrap_or_else(|err| panic!("error importing key: {}", err));
+        .unwrap_or_else(|err| panic!("error importing key: {err}"));
 
     assert_eq!(import_response.object_type, exported_key_type);
     assert_eq!(import_response.object_id, TEST_EXPORTED_KEY_ID);
 
     let imported_key_info = client
         .get_object_info(TEST_EXPORTED_KEY_ID, exported_key_type)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(imported_key_info.capabilities, exported_key_capabilities);
     assert_eq!(imported_key_info.object_id, TEST_EXPORTED_KEY_ID);

--- a/tests/command/generate_asymmetric_key.rs
+++ b/tests/command/generate_asymmetric_key.rs
@@ -13,7 +13,7 @@ fn ed25519_key_test() {
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AsymmetricKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(object_info.capabilities, capabilities);
     assert_eq!(object_info.object_id, TEST_KEY_ID);

--- a/tests/command/generate_hmac_key.rs
+++ b/tests/command/generate_hmac_key.rs
@@ -19,13 +19,13 @@ fn hmac_key_test() {
             capabilities,
             algorithm,
         )
-        .unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
+        .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 
     assert_eq!(key_id, TEST_KEY_ID);
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::HmacKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(object_info.capabilities, capabilities);
     assert_eq!(object_info.object_id, TEST_KEY_ID);

--- a/tests/command/generate_wrap_key.rs
+++ b/tests/command/generate_wrap_key.rs
@@ -24,13 +24,13 @@ fn wrap_key_test() {
             delegated_capabilities,
             algorithm,
         )
-        .unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
+        .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 
     assert_eq!(key_id, TEST_KEY_ID);
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::WrapKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(object_info.capabilities, capabilities);
     assert_eq!(object_info.object_id, TEST_KEY_ID);

--- a/tests/command/get_log_entries.rs
+++ b/tests/command/get_log_entries.rs
@@ -6,5 +6,5 @@ fn get_audit_logs_test() {
     // TODO: test audit logging functionality
     client
         .get_log_entries()
-        .unwrap_or_else(|err| panic!("error getting logs: {}", err));
+        .unwrap_or_else(|err| panic!("error getting logs: {err}"));
 }

--- a/tests/command/get_object_info.rs
+++ b/tests/command/get_object_info.rs
@@ -14,7 +14,7 @@ fn default_authkey_test() {
             DEFAULT_AUTHENTICATION_KEY_ID,
             object::Type::AuthenticationKey,
         )
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(object_info.capabilities, Capability::all());
     assert_eq!(object_info.object_id, DEFAULT_AUTHENTICATION_KEY_ID);

--- a/tests/command/get_option.rs
+++ b/tests/command/get_option.rs
@@ -5,7 +5,7 @@ fn command_audit_options_test() {
 
     let results = client
         .get_commands_audit_options()
-        .unwrap_or_else(|err| panic!("error getting force option: {}", err));
+        .unwrap_or_else(|err| panic!("error getting force option: {err}"));
 
     assert!(results.len() > 1);
 }
@@ -17,5 +17,5 @@ fn force_audit_option_test() {
 
     client
         .get_force_audit_option()
-        .unwrap_or_else(|err| panic!("error getting force option: {}", err));
+        .unwrap_or_else(|err| panic!("error getting force option: {err}"));
 }

--- a/tests/command/get_pseudo_random.rs
+++ b/tests/command/get_pseudo_random.rs
@@ -5,7 +5,7 @@ fn get_pseudo_random_test() {
 
     let bytes = client
         .get_pseudo_random(32)
-        .unwrap_or_else(|err| panic!("error getting random data: {}", err));
+        .unwrap_or_else(|err| panic!("error getting random data: {err}"));
 
     assert_eq!(32, bytes.len());
 }

--- a/tests/command/get_storage_info.rs
+++ b/tests/command/get_storage_info.rs
@@ -5,7 +5,7 @@ fn get_storage_info_test() {
 
     let response = client
         .get_storage_info()
-        .unwrap_or_else(|err| panic!("error getting storage status: {}", err));
+        .unwrap_or_else(|err| panic!("error getting storage status: {err}"));
 
     // TODO: these will probably have to change if Yubico releases new models
     assert_eq!(response.total_records, 256);

--- a/tests/command/list_objects.rs
+++ b/tests/command/list_objects.rs
@@ -14,13 +14,12 @@ fn list_objects_test() {
 
     let objects = client
         .list_objects(&[])
-        .unwrap_or_else(|err| panic!("error listing objects: {}", err));
+        .unwrap_or_else(|err| panic!("error listing objects: {err}"));
 
     // Look for the asymmetric key we just generated
     assert!(objects
         .iter()
-        .find(|i| i.object_id == TEST_KEY_ID && i.object_type == object::Type::AsymmetricKey)
-        .is_some());
+        .any(|i| i.object_id == TEST_KEY_ID && i.object_type == object::Type::AsymmetricKey));
 }
 
 /// Filter objects in the HSM by their type
@@ -30,7 +29,7 @@ fn list_objects_with_filter() {
 
     let objects = client
         .list_objects(&[object::Filter::Type(object::Type::AuthenticationKey)])
-        .unwrap_or_else(|err| panic!("error listing objects: {}", err));
+        .unwrap_or_else(|err| panic!("error listing objects: {err}"));
 
     assert!(objects
         .iter()

--- a/tests/command/put_asymmetric_key.rs
+++ b/tests/command/put_asymmetric_key.rs
@@ -15,7 +15,7 @@ fn ed25519_key_test() {
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AsymmetricKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(object_info.capabilities, capabilities);
     assert_eq!(object_info.object_id, TEST_KEY_ID);

--- a/tests/command/put_authentication_key.rs
+++ b/tests/command/put_authentication_key.rs
@@ -24,13 +24,13 @@ fn put_authentication_key() {
             algorithm,
             new_authentication_key,
         )
-        .unwrap_or_else(|err| panic!("error putting auth key: {}", err));
+        .unwrap_or_else(|err| panic!("error putting auth key: {err}"));
 
     assert_eq!(key_id, TEST_KEY_ID);
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AuthenticationKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
     assert_eq!(object_info.capabilities, capabilities);
     assert_eq!(object_info.object_id, TEST_KEY_ID);

--- a/tests/command/put_opaque.rs
+++ b/tests/command/put_opaque.rs
@@ -18,13 +18,13 @@ fn opaque_object_test() {
             opaque::Algorithm::Data,
             TEST_MESSAGE,
         )
-        .unwrap_or_else(|err| panic!("error putting opaque object: {}", err));
+        .unwrap_or_else(|err| panic!("error putting opaque object: {err}"));
 
     assert_eq!(object_id, TEST_KEY_ID);
 
     let opaque_data = client
         .get_opaque(TEST_KEY_ID)
-        .unwrap_or_else(|err| panic!("error getting opaque object: {}", err));
+        .unwrap_or_else(|err| panic!("error getting opaque object: {err}"));
 
     assert_eq!(opaque_data, TEST_MESSAGE);
 }

--- a/tests/command/set_option.rs
+++ b/tests/command/set_option.rs
@@ -9,11 +9,11 @@ fn command_audit_options_test() {
     for audit_option in &[AuditOption::On, AuditOption::Off] {
         client
             .set_command_audit_option(command_type, *audit_option)
-            .unwrap_or_else(|err| panic!("error setting {:?} audit option: {}", command_type, err));
+            .unwrap_or_else(|err| panic!("error setting {command_type:?} audit option: {err}"));
 
         let hsm_option = client
             .get_command_audit_option(command_type)
-            .unwrap_or_else(|err| panic!("error getting {:?} audit option: {}", command_type, err));
+            .unwrap_or_else(|err| panic!("error getting {command_type:?} audit option: {err}"));
 
         assert_eq!(hsm_option, *audit_option);
     }
@@ -30,22 +30,22 @@ fn force_audit_option_test() {
     // will prevent the tests from completing
     let audit_logs = client
         .get_log_entries()
-        .unwrap_or_else(|err| panic!("error getting audit logs: {}", err));
+        .unwrap_or_else(|err| panic!("error getting audit logs: {err}"));
 
     if let Some(last_entry) = audit_logs.entries.last() {
         client
             .set_log_index(last_entry.item)
-            .unwrap_or_else(|err| panic!("error setting audit log position: {}", err));
+            .unwrap_or_else(|err| panic!("error setting audit log position: {err}"));
     }
 
     for audit_option in &[AuditOption::On, AuditOption::Off] {
         client
             .set_force_audit_option(*audit_option)
-            .unwrap_or_else(|err| panic!("error setting force option: {}", err));
+            .unwrap_or_else(|err| panic!("error setting force option: {err}"));
 
         let hsm_option = client
             .get_force_audit_option()
-            .unwrap_or_else(|err| panic!("error getting force option: {}", err));
+            .unwrap_or_else(|err| panic!("error getting force option: {err}"));
 
         assert_eq!(hsm_option, *audit_option);
     }

--- a/tests/command/sign_eddsa.rs
+++ b/tests/command/sign_eddsa.rs
@@ -22,14 +22,14 @@ fn test_vectors() {
 
         let pubkey_response = client
             .get_public_key(TEST_KEY_ID)
-            .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+            .unwrap_or_else(|err| panic!("error getting public key: {err}"));
 
         assert_eq!(pubkey_response.algorithm, asymmetric::Algorithm::Ed25519);
         assert_eq!(pubkey_response.bytes, vector.pk);
 
         let signature = client
             .sign_ed25519(TEST_KEY_ID, vector.msg)
-            .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
+            .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {err}"));
 
         assert_eq!(vector.sig, &signature.to_bytes());
     }
@@ -48,13 +48,13 @@ fn generated_key_test() {
 
     let public_key = client
         .get_public_key(TEST_KEY_ID)
-        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+        .unwrap_or_else(|err| panic!("error getting public key: {err}"));
 
     assert_eq!(public_key.algorithm, asymmetric::Algorithm::Ed25519);
 
     let signature = client
         .sign_ed25519(TEST_KEY_ID, TEST_MESSAGE)
-        .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
+        .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {err}"));
 
     assert!(
         ed25519_dalek::VerifyingKey::try_from(public_key.ed25519().unwrap().as_ref())

--- a/tests/command/verify_hmac.rs
+++ b/tests/command/verify_hmac.rs
@@ -23,13 +23,13 @@ fn hmac_test_vectors() {
                 algorithm,
                 vector.key,
             )
-            .unwrap_or_else(|err| panic!("error putting HMAC key: {}", err));
+            .unwrap_or_else(|err| panic!("error putting HMAC key: {err}"));
 
         assert_eq!(key_id, TEST_KEY_ID);
 
         let tag = client
             .sign_hmac(TEST_KEY_ID, vector.msg)
-            .unwrap_or_else(|err| panic!("error computing HMAC of data: {}", err));
+            .unwrap_or_else(|err| panic!("error computing HMAC of data: {err}"));
 
         assert_eq!(tag.as_ref(), vector.tag);
 

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -67,7 +67,7 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
 #[test]
 fn ecdsa_nistp256_sign_test() {
     let signer = create_signer::<NistP256>(201);
-    let verify_key = p256::ecdsa::VerifyingKey::from_encoded_point(&signer.public_key()).unwrap();
+    let verify_key = p256::ecdsa::VerifyingKey::from_encoded_point(signer.public_key()).unwrap();
 
     let signature = signer.sign(TEST_MESSAGE);
     assert!(verify_key.verify(TEST_MESSAGE, &signature).is_ok());
@@ -77,7 +77,7 @@ fn ecdsa_nistp256_sign_test() {
 #[test]
 fn ecdsa_secp256k1_sign_test() {
     let signer = create_signer::<Secp256k1>(202);
-    let verify_key = k256::ecdsa::VerifyingKey::from_encoded_point(&signer.public_key()).unwrap();
+    let verify_key = k256::ecdsa::VerifyingKey::from_encoded_point(signer.public_key()).unwrap();
 
     let signature: ecdsa::Signature<Secp256k1> = signer.sign(TEST_MESSAGE);
     assert!(verify_key.verify(TEST_MESSAGE, &signature).is_ok());
@@ -89,7 +89,7 @@ fn ecdsa_secp256k1_sign_recover_test() {
     use k256::{ecdsa::VerifyingKey, PublicKey};
 
     let signer = create_signer::<Secp256k1>(203);
-    let verify_key = VerifyingKey::from_encoded_point(&signer.public_key()).unwrap();
+    let verify_key = VerifyingKey::from_encoded_point(signer.public_key()).unwrap();
 
     let digest = sha2::Sha256::new_with_prefix(TEST_MESSAGE);
 
@@ -99,9 +99,7 @@ fn ecdsa_secp256k1_sign_recover_test() {
 
     let recovered_key =
         VerifyingKey::recover_from_digest(digest.clone(), &signature, recovery_id).unwrap();
-    recovered_key
-        .verify_digest(digest.clone(), &signature)
-        .unwrap();
+    recovered_key.verify_digest(digest, &signature).unwrap();
 
     let recovered_pk = PublicKey::from(recovered_key);
     let signer_pk = PublicKey::from_encoded_point(signer.public_key()).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -102,23 +102,23 @@ pub fn create_mockhsm_connector() -> Connector {
 
 /// Delete the key in the test key slot (if it exists, otherwise do nothing)
 pub fn clear_test_key_slot(client: &Client, object_type: object::Type) {
-    println!("clearing test key slot: {:?} {}", object_type, TEST_KEY_ID);
+    println!("clearing test key slot: {object_type:?} {TEST_KEY_ID}");
 
     // Delete the key in TEST_KEY_ID slot it exists (we use it for testing)
     if let Err(e) = client.delete_object(TEST_KEY_ID, object_type) {
         // Ignore errors for nonexistent objects. We're here to make sure the
         // slot is clear, so it's irrelevant if there was no obj to begin with
         if e.device_error() != Some(device::ErrorKind::ObjectNotFound) {
-            panic!("error clearing test key: {}", e);
+            panic!("error clearing test key: {e}");
         }
     }
 
     // Ensure the object does not exist
     match client.get_object_info(TEST_KEY_ID, object_type) {
-        Ok(obj) => panic!("expected test key to be deleted! {:?}", obj),
+        Ok(obj) => panic!("expected test key to be deleted! {obj:?}"),
         Err(e) => {
             if e.device_error() != Some(device::ErrorKind::ObjectNotFound) {
-                panic!("error ensuring test key slot is clear: {}", e);
+                panic!("error ensuring test key slot is clear: {e}");
             }
         }
     }
@@ -140,7 +140,7 @@ pub fn generate_asymmetric_key(
         algorithm,
     ) {
         Ok(key_id) => assert_eq!(key_id, TEST_KEY_ID),
-        Err(e) => panic!("error generating asymmetric key: {}", e),
+        Err(e) => panic!("error generating asymmetric key: {e}"),
     }
 }
 
@@ -162,7 +162,7 @@ pub fn put_asymmetric_key<T: Into<Vec<u8>>>(
             algorithm,
             data,
         )
-        .unwrap_or_else(|err| panic!("error putting asymmetric key: {}", err));
+        .unwrap_or_else(|err| panic!("error putting asymmetric key: {err}"));
 
     assert_eq!(key_id, TEST_KEY_ID);
 }


### PR DESCRIPTION
MSRV is bumped due to the `time` dependency.

Bumps the following dependencies:

    $ cargo update
    Updating crates.io index
    Updating aead v0.5.1 -> v0.5.2
    Updating aes v0.8.2 -> v0.8.3
    Updating base64ct v1.5.3 -> v1.6.0
    Updating bitflags v2.2.1 -> v2.4.0
    Updating block-buffer v0.10.3 -> v0.10.4
    Updating block-padding v0.3.2 -> v0.3.3
    Updating cc v1.0.77 -> v1.0.82
    Updating chunked_transfer v1.4.0 -> v1.4.1
    Updating cipher v0.4.3 -> v0.4.4
    Updating const-oid v0.9.2 -> v0.9.5
    Updating crypto-bigint v0.5.0 -> v0.5.2
    Updating der v0.7.2 -> v0.7.8
      Adding deranged v0.3.7
    Updating digest v0.10.6 -> v0.10.7
    Updating ecdsa v0.16.6 -> v0.16.8
    Updating ed25519 v2.2.1 -> v2.2.2
    Updating elliptic-curve v0.13.3 -> v0.13.5
    Updating fiat-crypto v0.1.19 -> v0.1.20
    Updating generic-array v0.14.6 -> v0.14.7
    Updating getrandom v0.2.8 -> v0.2.10
    Updating httpdate v1.0.2 -> v1.0.3
    Updating itoa v1.0.4 -> v1.0.9
    Updating libc v0.2.137 -> v0.2.147
    Updating libm v0.2.6 -> v0.2.7
    Updating log v0.4.17 -> v0.4.20
    Updating num-bigint-dig v0.8.2 -> v0.8.4
    Updating num-traits v0.2.15 -> v0.2.16
    Updating once_cell v1.17.1 -> v1.18.0
    Updating pbkdf2 v0.12.1 -> v0.12.2
    Updating pkg-config v0.3.26 -> v0.3.27
    Updating primeorder v0.13.0 -> v0.13.2
    Updating quote v1.0.26 -> v1.0.32
    Updating rsa v0.9.1 -> v0.9.2
    Updating ryu v1.0.11 -> v1.0.15
    Updating sec1 v0.7.1 -> v0.7.3
    Updating serde v1.0.148 -> v1.0.183
    Updating serde_derive v1.0.148 -> v1.0.183
    Updating serde_json v1.0.89 -> v1.0.104
    Updating sha2 v0.10.6 -> v0.10.7
    Updating signature_derive v2.0.0 -> v2.0.1
    Updating smallvec v1.10.0 -> v1.11.0
    Updating spki v0.7.1 -> v0.7.2
    Updating subtle v2.4.1 -> v2.5.0
    Removing syn v1.0.104
    Removing syn v2.0.16
      Adding syn v2.0.28
    Removing synstructure v0.12.6
    Updating thiserror v1.0.40 -> v1.0.44
    Updating thiserror-impl v1.0.40 -> v1.0.44
    Updating time v0.3.20 -> v0.3.25
    Updating time-core v0.1.0 -> v0.1.1
    Updating time-macros v0.2.8 -> v0.2.11
    Updating typenum v1.15.0 -> v1.16.0
    Updating unicode-ident v1.0.5 -> v1.0.11
    Removing unicode-xid v0.2.4
    Updating uuid v1.3.3 -> v1.4.1
    Updating zeroize_derive v1.3.2 -> v1.4.2