### PR TITLE
fixup warning in documentation of `Client`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,7 +54,7 @@ use {
     sha2::{Digest, Sha256},
 };
 
-#[cfg(docsrs)]
+#[cfg(any(doc, docsrs))]
 use crate::ecdsa;
 
 /// YubiHSM client: main API in this crate for accessing functions of the


### PR DESCRIPTION
```
warning: unresolved link to `ecdsa::Signer`
   --> src/client.rs:975:34
    |
975 |     /// We recommend using the [`ecdsa::Signer`] type instead, which provides a
    |                                  ^^^^^^^^^^^^^ no item named `Signer` in module `ecdsa`
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```