### PR TITLE
ecdsa: provide der-encoded signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,8 +232,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -332,6 +345,12 @@ name = "fiat-crypto"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+
+[[package]]
+name = "flagset"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
 
 [[package]]
 name = "generic-array"
@@ -755,6 +774,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +956,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eefca1d99701da3a57feb07e5079fc62abba059fc139e98c13bbb250f3ef29"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "yubihsm"
 version = "0.42.1"
 dependencies = [
@@ -953,11 +996,13 @@ dependencies = [
  "serde_json",
  "sha2",
  "signature",
+ "spki",
  "subtle",
  "thiserror",
  "time",
  "tiny_http",
  "uuid",
+ "x509-cert",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bitflags = "2"
 cmac = "0.7"
 cbc = "0.1"
 ccm = { version = "0.5", features = ["std"] }
-ecdsa = { version = "0.16", default-features = false }
+ecdsa = { version = "0.16", default-features = false, features = ["pkcs8"] }
 ed25519 = "2"
 log = "0.4"
 num-traits = "0.2"
@@ -32,6 +32,8 @@ serde = { version = "1", features = ["serde_derive"] }
 rand_core = { version = "0.6", features = ["std"] }
 rsa = "0.9.6"
 signature = { version = "2", features = ["derive"] }
+sha2 = { version = "0.10", features = ["oid"] }
+spki = { version = "0.7.3", default-features = false }
 subtle = "2"
 thiserror = "1"
 time = { version = "0.3", features = ["serde"] }
@@ -46,23 +48,23 @@ k256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
 pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
 serde_json = { version = "1", optional = true }
 rusb = { version = "0.9", optional = true }
-sha2 = { version = "0.10", optional = true }
 tiny_http = { version = "0.12", optional = true }
 
 [dev-dependencies]
 ed25519-dalek = "2"
 once_cell = "1"
 p256 = { version = "0.13", features = ["ecdsa"] }
+x509-cert = { version = "0.2.4", features = ["builder"] }
 
 [features]
 default = ["http", "passwords", "setup"]
 http-server = ["tiny_http"]
 http = []
 mockhsm = ["digest", "ecdsa/arithmetic", "ed25519-dalek", "p256/ecdsa", "secp256k1"]
-passwords = ["hmac", "pbkdf2", "sha2"]
+passwords = ["hmac", "pbkdf2"]
 secp256k1 = ["k256"]
 setup = ["passwords", "serde_json", "uuid/serde"]
-untested = ["sha2"]
+untested = []
 usb = ["rusb"]
 
 [package.metadata.docs.rs]

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroize;
 #[cfg(feature = "pbkdf2")]
 use pbkdf2::pbkdf2_hmac;
 
-#[cfg(feature = "sha2")]
+#[cfg(feature = "passwords")]
 use sha2::Sha256;
 
 /// Auth keys are 2 * AES-128 keys


### PR DESCRIPTION
this allows users to use the `ecdsa::Signer` to build x509, CSR or other objects.