### PR TITLE
.cargo/audit.toml: ignore RUSTSEC-2023-0071

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,4 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2020-0071",
-    "RUSTSEC-2020-0159",
+    "RUSTSEC-2023-0071", # rsa: Marvin Attack: potential key recovery
 ]


### PR DESCRIPTION
It's not actionable until a new release of the `rsa` crate is available