### PR TITLE
Compatibility fixes and a standalone mockhsm example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[example]]
 name = "connector_http_server"
 required-features = ["http-server", "usb"]
+
+[[example]]
+name = "mockhsm"
+required-features = ["http-server", "mockhsm"]

--- a/examples/mockhsm.rs
+++ b/examples/mockhsm.rs
@@ -1,0 +1,30 @@
+//! `yubihsm-connector` compatible HTTP server example.
+//!
+//! This exposes an HTTP server which provides an API that is compatible with
+//! the `yubihsm-connector` executable which comes with the YubiHSM SDK.
+//!
+//! It allows utilities like `yubihsm-shell` or other things written with
+//! `libyubihsm` to function in tandem with a Rust application
+//! communicating directly with the YubiHSM2 over USB.
+
+fn main() {
+    println!("using mockhsm");
+    let connector = yubihsm::Connector::mockhsm();
+
+    // http://127.0.0.1:12345
+    let http_config = yubihsm::connector::HttpConfig::default();
+
+    println!(
+        "starting server at http://{}:{}",
+        &http_config.addr, http_config.port
+    );
+
+    let server = yubihsm::connector::http::Server::new(&http_config, connector).unwrap();
+
+    println!("server started! connect by running:\n");
+    println!("    $ yubihsm-shell");
+    println!("    yubihsm> connect");
+    println!("    yubihsm> session open 1 <password>");
+
+    server.run().unwrap();
+}

--- a/src/audit/commands/set_option.rs
+++ b/src/audit/commands/set_option.rs
@@ -3,11 +3,7 @@
 //! For more information, see:
 //! <https://developers.yubico.com/YubiHSM2/Commands/Set_Option.html>
 
-use crate::{
-    audit::*,
-    command::{self, Command},
-    response::Response,
-};
+use crate::{audit::*, command::Command, response::Response};
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for `command::put_option`

--- a/src/connector/http/client/connection.rs
+++ b/src/connector/http/client/connection.rs
@@ -5,10 +5,8 @@ use std::{
     io::Write,
     net::{TcpStream, ToSocketAddrs},
     ops::DerefMut,
-    string::String,
     sync::Mutex,
     time::Duration,
-    vec::Vec,
 };
 
 use super::{error::Error, path::PathBuf, request, response, HTTP_VERSION, USER_AGENT};

--- a/src/connector/http/client/error.rs
+++ b/src/connector/http/client/error.rs
@@ -3,10 +3,7 @@
 #![allow(unused_macros)]
 
 use std::{fmt, num::ParseIntError, str::Utf8Error};
-use std::{
-    io,
-    string::{FromUtf8Error, String, ToString},
-};
+use std::{io, string::FromUtf8Error};
 
 /// Error type
 #[derive(Debug)]

--- a/src/connector/http/client/response/reader.rs
+++ b/src/connector/http/client/response/reader.rs
@@ -4,7 +4,7 @@
 
 use super::Body;
 use crate::connector::http::client::Error;
-use std::{io::Read, str, vec::Vec};
+use std::{io::Read, str};
 
 const TRANSFER_ENCODING_HEADER: &str = "Transfer-Encoding: ";
 const HEADER_DELIMITER: &[u8] = b"\r\n\r\n";

--- a/src/connector/http/server.rs
+++ b/src/connector/http/server.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     uuid,
 };
-use std::{io, process, time::Instant};
+use std::{fmt::Write, io, process, time::Instant};
 use tiny_http as http;
 
 /// `yubihsm-connector` compatible HTTP server
@@ -107,11 +107,10 @@ impl Server {
             ("port", &self.port.to_string()),
         ];
 
-        let body = status
-            .iter()
-            .map(|(k, v)| [*k, *v].join("\n"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        let body = status.iter().fold(String::new(), |mut body, (k, v)| {
+            let _ = writeln!(body, "{k}={v}");
+            body
+        });
 
         Ok(http::Response::from_string(body))
     }

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -156,7 +156,7 @@ fn delete_object(state: &mut State, cmd_data: &[u8]) -> response::Message {
 }
 
 /// Generate a mock device information report
-fn device_info() -> response::Message {
+pub(crate) fn device_info() -> response::Message {
     let info = device::Info {
         major_version: 2,
         minor_version: 0,

--- a/src/mockhsm/connection.rs
+++ b/src/mockhsm/connection.rs
@@ -34,6 +34,7 @@ impl Connection for MockConnection {
             Code::CreateSession => command::create_session(&mut state, &command),
             Code::AuthenticateSession => command::authenticate_session(&mut state, &command),
             Code::SessionMessage => command::session_message(&mut state, command),
+            Code::DeviceInfo => Ok(command::device_info().into()),
             unsupported => fail!(ConnectionFailed, "unsupported command: {:?}", unsupported),
         }
         .map(Message::from)

--- a/src/rsa/pss/commands.rs
+++ b/src/rsa/pss/commands.rs
@@ -30,7 +30,7 @@ impl Command for SignPssCommand {
 
 /// RSASSA-PSS signatures (ASN.1 DER encoded)
 #[derive(Serialize, Deserialize, Debug)]
-pub struct SignPssResponse(rsa::pss::Signature);
+pub struct SignPssResponse(pub(crate) rsa::pss::Signature);
 
 impl Response for SignPssResponse {
     const COMMAND_CODE: command::Code = command::Code::SignPss;

--- a/src/serialization/ser.rs
+++ b/src/serialization/ser.rs
@@ -97,9 +97,9 @@ impl<'a, W: Write> serde::Serializer for &'a mut Serializer<W> {
         unimplemented!();
     }
 
-    fn serialize_some<T: ?Sized>(self, _v: &T) -> Result<(), Error>
+    fn serialize_some<T>(self, _v: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         unimplemented!();
     }
@@ -195,9 +195,9 @@ impl<'a, W: Write> SerializeSeq for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -213,9 +213,9 @@ impl<'a, W: Write> SerializeTuple for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -231,9 +231,9 @@ impl<'a, W: Write> SerializeTupleStruct for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -249,9 +249,9 @@ impl<'a, W: Write> SerializeTupleVariant for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -267,17 +267,17 @@ impl<'a, W: Write> SerializeMap for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_key<K: ?Sized>(&mut self, value: &K) -> Result<(), Error>
+    fn serialize_key<K>(&mut self, value: &K) -> Result<(), Error>
     where
-        K: serde::Serialize,
+        K: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
 
     #[inline]
-    fn serialize_value<V: ?Sized>(&mut self, value: &V) -> Result<(), Error>
+    fn serialize_value<V>(&mut self, value: &V) -> Result<(), Error>
     where
-        V: serde::Serialize,
+        V: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -293,9 +293,9 @@ impl<'a, W: Write> SerializeStruct for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, _key: &'static str, value: &T) -> Result<(), Error>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -311,9 +311,9 @@ impl<'a, W: Write> SerializeStructVariant for SerializeHelper<'a, W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, _key: &'static str, value: &T) -> Result<(), Error>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -628,7 +628,6 @@ fn compute_icv(cipher: &Aes128, counter: u32) -> GenericArray<u8, U16> {
 #[cfg(all(test, feature = "mockhsm"))]
 mod tests {
     use super::*;
-    use crate::authentication;
 
     const PASSWORD: &[u8] = b"password";
     const HOST_CHALLENGE: &[u8] = &[0u8; 8];

--- a/src/session/securechannel/challenge.rs
+++ b/src/session/securechannel/challenge.rs
@@ -31,7 +31,7 @@ impl Challenge {
     }
 
     /// Borrow the challenge value as a slice
-    #[cfg_attr(clippy, allow(clippy::trivially_copy_pass_by_ref))]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn as_slice(&self) -> &[u8] {
         &self.0
     }

--- a/tests/command/decrypt_oaep.rs
+++ b/tests/command/decrypt_oaep.rs
@@ -1,6 +1,5 @@
 use crate::{generate_asymmetric_key, TEST_KEY_ID};
-use rand_core;
-use sha2::{self, Digest};
+use sha2::Digest;
 use yubihsm::{asymmetric, Capability};
 
 /// Test RSA OAEP decryption


### PR DESCRIPTION
This branch contains a small series of compatibility fixes needed to create a standalone `mockhsm` example application. I use this standalone application to test a [Go based library](https://github.com/nholstein/yubihsm) I've developed.

There's four types of fixes:

 * warnings from a newer `clippy` version (1.78)
 * correct the `key=value\n` in the HTTP /status endpoint
 * RSASSA-PSS signature support in mockhsm
 * allow device-info outside an authenticated session

Additionally, I tested this using a new examples/mockhsm.rs which exports the mockhsm via HTTP. I thought it might be useful for others, but this commit could easily be reverted if not desired.