### PR TITLE
serializer: enforce serialization as array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "signature",
  "spki",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bitflags = "2"
 cmac = "0.7"
 cbc = "0.1"
 ccm = { version = "0.5", features = ["std"] }
+digest = { version = "0.10", default-features = false }
 ecdsa = { version = "0.16", default-features = false, features = ["pkcs8"] }
 ed25519 = "2"
 log = "0.4"
@@ -41,12 +42,12 @@ uuid = { version = "1", default-features = false }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # optional dependencies
-digest = { version = "0.10", optional = true, default-features = false }
 ed25519-dalek = { version = "2", optional = true, features = ["rand_core"] }
 hmac = { version = "0.12", optional = true }
 k256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
 pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
 serde_json = { version = "1", optional = true }
+sha1 = { version = "0.10", optional = true }
 rusb = { version = "0.9", optional = true }
 tiny_http = { version = "0.12", optional = true }
 
@@ -60,7 +61,7 @@ x509-cert = { version = "0.2.5", features = ["builder"] }
 default = ["http", "passwords", "setup"]
 http-server = ["tiny_http"]
 http = []
-mockhsm = ["digest", "ecdsa/arithmetic", "ed25519-dalek", "p256/ecdsa", "secp256k1"]
+mockhsm = ["ecdsa/arithmetic", "ed25519-dalek", "p256/ecdsa", "secp256k1", "sha1"]
 passwords = ["hmac", "pbkdf2"]
 secp256k1 = ["k256"]
 setup = ["passwords", "serde_json", "uuid/serde"]

--- a/src/rsa/oaep/commands.rs
+++ b/src/rsa/oaep/commands.rs
@@ -6,10 +6,13 @@ use crate::{
     response::Response,
     rsa,
 };
-use serde::{Deserialize, Serialize};
+use digest::{typenum::Unsigned, OutputSizeUser};
+use serde::{de::Deserializer, Deserialize, Serialize};
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
 
 /// Request parameters for `command::decrypt_rsa_oaep`
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub(crate) struct DecryptOaepCommand {
     /// ID of the decryption key
     pub key_id: object::Id,
@@ -39,5 +42,48 @@ impl Response for DecryptOaepResponse {
 impl From<DecryptOaepResponse> for rsa::oaep::DecryptedData {
     fn from(response: DecryptOaepResponse) -> rsa::oaep::DecryptedData {
         response.0
+    }
+}
+
+impl<'de> Deserialize<'de> for DecryptOaepCommand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct DecryptOaepCommand {
+            /// ID of the decryption key
+            key_id: object::Id,
+
+            /// Hash algorithm to use for MGF1
+            mgf1_hash_alg: rsa::mgf::Algorithm,
+
+            /// Data to be decrypted
+            data: Vec<u8>,
+        }
+
+        let mut value = DecryptOaepCommand::deserialize(deserializer)?;
+
+        let label_hash = match value.mgf1_hash_alg {
+            rsa::mgf::Algorithm::Sha1 => value
+                .data
+                .split_off(value.data.len() - <Sha1 as OutputSizeUser>::OutputSize::USIZE),
+            rsa::mgf::Algorithm::Sha256 => value
+                .data
+                .split_off(value.data.len() - <Sha256 as OutputSizeUser>::OutputSize::USIZE),
+            rsa::mgf::Algorithm::Sha384 => value
+                .data
+                .split_off(value.data.len() - <Sha384 as OutputSizeUser>::OutputSize::USIZE),
+            rsa::mgf::Algorithm::Sha512 => value
+                .data
+                .split_off(value.data.len() - <Sha512 as OutputSizeUser>::OutputSize::USIZE),
+        };
+
+        Ok(Self {
+            key_id: value.key_id,
+            mgf1_hash_alg: value.mgf1_hash_alg,
+            data: value.data,
+            label_hash,
+        })
     }
 }


### PR DESCRIPTION
The implementation of array deserializer expects the payload to be serialized as array. Sadly the serializer left the door open for the underlying serializer to choice either bytes or array, if available.

This would only occur when the objects are used outside yubihsm.rs.

This change was tested on both mockhsm and yubihsm on usb.