### PR TITLE
oaep: fixup `Deserialize` implementation

### DIFF
--- a/src/rsa/oaep/commands.rs
+++ b/src/rsa/oaep/commands.rs
@@ -6,10 +6,15 @@ use crate::{
     response::Response,
     rsa,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::Deserializer, Deserialize, Serialize};
+use sha1::Sha1;
+use sha2::{
+    digest::{typenum::Unsigned, OutputSizeUser},
+    Sha256, Sha384, Sha512,
+};
 
 /// Request parameters for `command::decrypt_rsa_oaep`
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub(crate) struct DecryptOaepCommand {
     /// ID of the decryption key
     pub key_id: object::Id,
@@ -39,5 +44,48 @@ impl Response for DecryptOaepResponse {
 impl From<DecryptOaepResponse> for rsa::oaep::DecryptedData {
     fn from(response: DecryptOaepResponse) -> rsa::oaep::DecryptedData {
         response.0
+    }
+}
+
+impl<'de> Deserialize<'de> for DecryptOaepCommand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct DecryptOaepCommand {
+            /// ID of the decryption key
+            key_id: object::Id,
+
+            /// Hash algorithm to use for MGF1
+            mgf1_hash_alg: rsa::mgf::Algorithm,
+
+            /// Data to be decrypted
+            data: Vec<u8>,
+        }
+
+        let mut value = DecryptOaepCommand::deserialize(deserializer)?;
+
+        let label_hash = match value.mgf1_hash_alg {
+            rsa::mgf::Algorithm::Sha1 => value
+                .data
+                .split_off(value.data.len() - <Sha1 as OutputSizeUser>::OutputSize::USIZE),
+            rsa::mgf::Algorithm::Sha256 => value
+                .data
+                .split_off(value.data.len() - <Sha256 as OutputSizeUser>::OutputSize::USIZE),
+            rsa::mgf::Algorithm::Sha384 => value
+                .data
+                .split_off(value.data.len() - <Sha384 as OutputSizeUser>::OutputSize::USIZE),
+            rsa::mgf::Algorithm::Sha512 => value
+                .data
+                .split_off(value.data.len() - <Sha512 as OutputSizeUser>::OutputSize::USIZE),
+        };
+
+        Ok(Self {
+            key_id: value.key_id,
+            mgf1_hash_alg: value.mgf1_hash_alg,
+            data: value.data,
+            label_hash,
+        })
     }
 }


### PR DESCRIPTION
label_data was always empty because it was consumed by data.

This commits re-splits the payload according to the selected mgf hash.