### PR TITLE
serializer: force serialization as array

### DIFF
--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -25,7 +25,12 @@ macro_rules! impl_array_serializers {
     ($ty:ident, $size:expr) => {
         impl ::serde::Serialize for $ty {
             fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                self.0.serialize(serializer)
+                use ::serde::ser::SerializeSeq;
+                let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+                for element in self.0.iter() {
+                    seq.serialize_element(element)?;
+                }
+                seq.end()
             }
         }
 


### PR DESCRIPTION
The implementation of array deserializer expects the payload to be serialized as array. Sadly the serializer left the door open for the underlying serializer to choice either bytes or array, if available.

This would only occur when the objects are used outside yubihsm.rs.

This change was tested on both mockhsm and yubihsm on usb.