### PR TITLE
ci: run ci with specified versions of rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
         toolchain:
           - stable
           - 1.67.0 # MSRV
@@ -35,9 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
         toolchain:
           - stable
           - 1.67.0 # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,25 +22,9 @@ jobs:
           - 1.67.0 # MSRV
     steps:
       - uses: actions/checkout@v1
-      - name: cache .cargo/registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - name: cache .cargo/git
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-      - name: cache target
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-rust-${{ matrix.toolchain }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
       - run: cargo build --release
       - run: cargo build --release --no-default-features
       - run: cargo build --release --no-default-features --features=passwords
@@ -59,25 +43,9 @@ jobs:
           - 1.67.0 # MSRV
     steps:
       - uses: actions/checkout@v1
-      - name: cache .cargo/registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - name: cache .cargo/git
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-      - name: cache target
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-rust-${{ matrix.toolchain }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
       - run: cargo test --features=mockhsm,secp256k1,untested
 
   rustfmt:
@@ -85,12 +53,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
-          override: true
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -101,12 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.71.0 # pinned to prevent CI breakages
           components: clippy
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-rust-${{ matrix.toolchain }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
       - run: cargo test --features=mockhsm,secp256k1,untested
 
   rustfmt:

--- a/tests/test_vectors/mod.rs
+++ b/tests/test_vectors/mod.rs
@@ -14,6 +14,7 @@ pub use self::ed25519::ED25519_TEST_VECTORS;
 pub use self::hmac::HMAC_SHA256_TEST_VECTORS;
 
 /// Authenticated encryption test vector (presently specialized for AES-CCM)
+#[allow(dead_code)]
 pub struct EncryptionTestVector {
     /// Encryption key
     pub key: &'static [u8],


### PR DESCRIPTION
The tests were running with ambiant version of rust. GitHub just updated the rust version to 1.79
https://github.com/actions/runner-images/blob/ubuntu22/20240616.1/images/ubuntu/Ubuntu2204-Readme.md