### PR TITLE
rusb: mitigate API break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.42.1"
+version = "0.43.0-pre"
 dependencies = [
  "aes",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ hmac = { version = "0.12", optional = true }
 k256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
 pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
 serde_json = { version = "1", optional = true }
-rusb = { version = "0.9", optional = true }
+rusb = { version = "0.9.4", optional = true }
 tiny_http = { version = "0.12", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
rusb introduced an API break between 0.9.3 and 0.9.4.

https://github.com/a1ien/rusb/compare/v0.9.3-rusb..v0.9.4-rusb#diff-d5edd151ab03396da2ef0f89796c9fc95e3bec5e1a6a7a3ac5e46ead5e676a4dL225