### PR TITLE
session: avoid unnecessary timeouts

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -225,6 +225,7 @@ impl Session {
                 return Err(e.into());
             }
         };
+        self.last_active = Instant::now();
 
         if response.is_err() {
             session_error!(self, "uuid={} error={:?}", &uuid, response.code);


### PR DESCRIPTION
When a slow operation is running on the HSM (like a RSA key generation >= 3072), the HSM will be busy for more than the session timeout of 30seconds.

Although the device did not reply within timeout, it did not discard the session, and we should not either. This bumps the last_active when we receive a reply from the HSM.