### PR TITLE
session: expose derive_keys

### DIFF
--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -182,9 +182,7 @@ impl SecureChannel {
         card_challenge: Challenge,
     ) -> Self {
         let context = Context::from_challenges(host_challenge, card_challenge);
-        let enc_key = derive_key(authentication_key.enc_key(), 0b100, &context);
-        let mac_key = derive_key(authentication_key.mac_key(), 0b110, &context);
-        let rmac_key = derive_key(authentication_key.mac_key(), 0b111, &context);
+        let session_keys = context.derive_keys(authentication_key);
         let mac_chaining_value = [0u8; Mac::BYTE_SIZE * 2];
 
         Self {
@@ -192,9 +190,9 @@ impl SecureChannel {
             counter: 0,
             security_level: SecurityLevel::None,
             context,
-            enc_key,
-            mac_key,
-            rmac_key,
+            enc_key: session_keys.enc_key,
+            mac_key: session_keys.mac_key,
+            rmac_key: session_keys.rmac_key,
             mac_chaining_value,
         }
     }

--- a/src/session/securechannel/context.rs
+++ b/src/session/securechannel/context.rs
@@ -1,6 +1,7 @@
 //! Derivation context (i.e. concatenated challenges)
 
-use super::{Challenge, CHALLENGE_SIZE};
+use super::{derive_key, Challenge, SessionKeys, CHALLENGE_SIZE};
+use crate::authentication;
 
 /// Size of a session context
 const CONTEXT_SIZE: usize = CHALLENGE_SIZE * 2;
@@ -20,5 +21,18 @@ impl Context {
     /// Borrow the context value as a slice
     pub fn as_slice(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Derive session keys from context and authentication key
+    pub fn derive_keys(&self, authentication_key: &authentication::Key) -> SessionKeys {
+        let enc_key = derive_key(authentication_key.enc_key(), 0b100, self);
+        let mac_key = derive_key(authentication_key.mac_key(), 0b110, self);
+        let rmac_key = derive_key(authentication_key.mac_key(), 0b111, self);
+
+        SessionKeys {
+            enc_key,
+            mac_key,
+            rmac_key,
+        }
     }
 }


### PR DESCRIPTION
This is used to compute sessions keys from a context directly.