### PR TITLE
audit: fixup log entry serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1008,7 @@ dependencies = [
  "ecdsa",
  "ed25519",
  "ed25519-dalek",
+ "hex-literal",
  "hmac",
  "k256",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tiny_http = { version = "0.12", optional = true }
 
 [dev-dependencies]
 ed25519-dalek = "2"
+hex-literal = "0.4"
 once_cell = "1"
 rsa = { version = "0.9.6", features = ["sha1", "sha2"] }
 p256 = { version = "0.13", features = ["ecdsa"] }

--- a/src/audit/commands/get_log_entries.rs
+++ b/src/audit/commands/get_log_entries.rs
@@ -70,6 +70,17 @@ pub struct LogEntry {
     pub digest: LogDigest,
 }
 
+impl LogEntry {
+    /// The payload used to rebuild the hash of the log entry.
+    pub fn digest_payload(&self) -> Result<Box<[u8]>, serialization::Error> {
+        let mut out = serialize(self)?;
+
+        // Strip out the digest
+        out.resize(out.len() - LOG_DIGEST_SIZE, 0);
+        Ok(out.into_boxed_slice())
+    }
+}
+
 /// Size of a truncated digest in the log
 pub const LOG_DIGEST_SIZE: usize = 16;
 


### PR DESCRIPTION
When serializing response codes, in the case of an error, the payload would be serialized differently than what the device gives us.

In the case of a soft error, the response code should be serialized from the bottom up, and not from the midpoint like it was.
This was breaking the hash computation.

This introduces a new type for the purpose of audit log which represent the correct behavior. That fixes two cases I've observed: the log in the case of a reboot and the error in case an object would not exist.