### PR TITLE
mockhsm(rsa): when wrapped, the modulus is appended to the message

### DIFF
--- a/src/mockhsm/object/payload.rs
+++ b/src/mockhsm/object/payload.rs
@@ -209,6 +209,8 @@ impl Payload {
                 if let Some(qinv) = k.qinv() {
                     out.extend_from_slice(&qinv.to_bytes_be().1)
                 }
+                // n
+                out.extend_from_slice(&k.n().to_bytes_be());
 
                 out
             }


### PR DESCRIPTION
This fixes the implementation made in #510 

Tested against the mockhsm and a real device on USB.