### PR TITLE
expose derive keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           toolchain: 1.85.0 # pinned to prevent CI breakages
           components: clippy
+      - run: sudo apt-get install libpcsclite-dev
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
@@ -83,6 +89,12 @@ checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cbc"
@@ -204,7 +216,7 @@ checksum = "9fde2467e74147f492aebb834985186b2c74761927b8b9b3bd303bcb2e72199d"
 dependencies = [
  "cpubits",
  "ctutils",
- "getrandom",
+ "getrandom 0.4.2",
  "hybrid-array",
  "num-traits",
  "rand_core",
@@ -219,7 +231,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "hybrid-array",
  "rand_core",
 ]
@@ -325,6 +337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3214053e68a813b9c06ef61075c844f3a1cdeb307d8998ea8555c063caa52fa9"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,7 +391,9 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core",
+ "serde",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -429,13 +452,25 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core",
  "wasip2",
  "wasip3",
@@ -529,6 +564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "k256"
 version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +627,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-conv"
@@ -653,6 +707,25 @@ checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
+dependencies = [
+ "bitflags",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ef017e15d2e5592a9e39a346c1dbaea5120bab7ed7106b210ef58ebd97003"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -749,6 +822,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -760,7 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
@@ -841,6 +920,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +942,15 @@ dependencies = [
  "der",
  "hybrid-array",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
  "zeroize",
 ]
 
@@ -1091,7 +1185,10 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
  "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1116,6 +1213,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1247,6 +1389,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-cert"
 version = "0.3.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1451,42 @@ dependencies = [
  "time",
  "tiny_http",
  "uuid",
+ "x509-cert",
+ "yubikey",
+ "zeroize",
+]
+
+[[package]]
+name = "yubikey"
+version = "0.8.0"
+source = "git+https://github.com/baloo/yubikey.rs?branch=baloo%2Fyubihsm-auth#32d4e409cb4af7f74ea69d5dfe464dbc54400303"
+dependencies = [
+ "aes",
+ "base16ct 0.2.0",
+ "bitflags",
+ "cipher",
+ "curve25519-dalek",
+ "der",
+ "des",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "log",
+ "nom",
+ "p256",
+ "p384",
+ "pbkdf2",
+ "pcsc",
+ "rand",
+ "rand_core",
+ "rsa",
+ "secrecy",
+ "sha1",
+ "sha2",
+ "signature",
+ "subtle",
+ "uuid",
+ "x25519-dalek",
  "x509-cert",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ serde_json = { version = "1", optional = true }
 rusb = { version = "0.9.4", optional = true }
 tiny_http = { version = "0.12", optional = true }
 x509-cert = { version = "0.3.0-rc.4", features = ["builder", "hazmat"], optional = true }
+yubikey = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 ed25519-dalek = "3.0.0-pre.6"
@@ -84,6 +85,7 @@ secp256k1 = ["k256"]
 setup = ["passwords", "serde_json", "uuid/serde"]
 untested = []
 usb = ["rusb"]
+yubihsm-auth = ["yubikey"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -92,3 +94,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[example]]
 name = "connector_http_server"
 required-features = ["http-server", "usb"]
+
+[patch.crates-io]
+yubikey = { git = "https://github.com/baloo/yubikey.rs", branch = "baloo/yubihsm-auth"}

--- a/src/client.rs
+++ b/src/client.rs
@@ -45,6 +45,9 @@ use std::{
 #[cfg(feature = "passwords")]
 use std::{thread, time::SystemTime};
 
+#[cfg(feature = "yubihsm-auth")]
+use crate::session::PendingSession;
+
 #[cfg(feature = "untested")]
 use crate::{
     algorithm::Algorithm,
@@ -102,6 +105,20 @@ impl Client {
         };
 
         Ok(client)
+    }
+
+    /// Open session with YubiHSM Auth scheme
+    #[cfg(feature = "yubihsm-auth")]
+    pub fn yubihsm_auth(
+        connector: Connector,
+        authentication_key_id: object::Id,
+        host_challenge: session::securechannel::Challenge,
+    ) -> Result<PendingSession, Error> {
+        let timeout = session::Timeout::default();
+
+        let session =
+            PendingSession::new(connector, timeout, authentication_key_id, host_challenge)?;
+        Ok(session)
     }
 
     /// Borrow this client's YubiHSM connector (which is `Clone`able)
@@ -1215,5 +1232,17 @@ impl Client {
                 plaintext,
             })?
             .0)
+    }
+}
+
+impl From<Session> for Client {
+    fn from(session: Session) -> Self {
+        let connector = session.connector();
+        let session = Arc::new(Mutex::new(Some(session)));
+        Self {
+            connector,
+            session,
+            credentials: None,
+        }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,6 +17,7 @@ pub use self::{
     error::{Error, ErrorKind},
     guard::Guard,
     id::Id,
+    securechannel::{Challenge, Context, SessionKeys},
     timeout::Timeout,
 };
 
@@ -30,12 +31,107 @@ use crate::{
 };
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "yubihsm-auth")]
+use crate::object;
+
 /// Timeout fuzz factor: to avoid races/skew with the YubiHSM's clock,
 /// we consider sessions to be timed out slightly earlier than the actual
 /// timeout. This should (hopefully) ensure we always time out first,
 /// and therefore generate appropriate timeout-related errors rather
 /// than opaque "lost connection to HSM"-style errors.
 const TIMEOUT_FUZZ_FACTOR: Duration = Duration::from_secs(1);
+
+/// Session created on the device for which we do not
+/// have credentials for yet.
+///
+/// This is used for YubiHSM Auth scheme support.
+#[cfg(feature = "yubihsm-auth")]
+pub struct PendingSession {
+    ///// HSM Public key
+    //card_public_key: PublicKey,
+    /// Connector which communicates with the HSM (HTTP or USB)
+    connector: Connector,
+
+    /// Session creation timestamp
+    created_at: Instant,
+
+    /// Timestamp when this session was last active
+    last_active: Instant,
+
+    /// Inactivity timeout for this session
+    timeout: Timeout,
+
+    /// Challenge generate by the HSM.
+    hsm_challenge: Challenge,
+
+    /// ID for this session
+    id: Id,
+
+    context: Context,
+}
+
+#[cfg(feature = "yubihsm-auth")]
+impl PendingSession {
+    /// Creates a new session with the device.
+    pub fn new(
+        connector: Connector,
+        timeout: Timeout,
+        authentication_key_id: object::Id,
+        host_challenge: Challenge,
+    ) -> Result<Self, Error> {
+        let (id, session_response) =
+            SecureChannel::create(&connector, authentication_key_id, host_challenge)?;
+
+        let hsm_challenge = session_response.card_challenge;
+        let context = Context::from_challenges(host_challenge, hsm_challenge);
+
+        let created_at = Instant::now();
+        let last_active = Instant::now();
+
+        Ok(PendingSession {
+            id,
+            connector,
+            created_at,
+            last_active,
+            timeout,
+            context,
+            hsm_challenge,
+        })
+    }
+
+    /// Create the session with the provided session keys
+    pub fn realize(self, session_keys: SessionKeys) -> Result<Session, Error> {
+        let secure_channel = Some(SecureChannel::with_session_keys(
+            self.id,
+            self.context,
+            session_keys,
+        ));
+
+        let mut session = Session {
+            id: self.id,
+            secure_channel,
+            connector: self.connector,
+            created_at: self.created_at,
+            last_active: self.last_active,
+            timeout: self.timeout,
+        };
+
+        let response = session.start_authenticate()?;
+        session.finish_authenticate_session(&response)?;
+
+        Ok(session)
+    }
+
+    /// Return the challenge emitted by the HSM when opening the session
+    pub fn get_challenge(&self) -> Challenge {
+        self.hsm_challenge
+    }
+
+    /// Return the id of the session
+    pub fn id(&self) -> Id {
+        self.id
+    }
+}
 
 /// Authenticated and encrypted (SCP03) `Session` with the HSM. A `Session` is
 /// needed to perform any command.
@@ -246,13 +342,9 @@ impl Session {
             credentials.authentication_key_id
         );
 
-        let command = self.secure_channel()?.authenticate_session()?;
-        let response = self.send_message(command)?;
+        let response = self.start_authenticate()?;
 
-        if let Err(e) = self
-            .secure_channel()?
-            .finish_authenticate_session(&response)
-        {
+        if let Err(e) = self.finish_authenticate_session(&response) {
             session_error!(
                 self,
                 "failed={:?} key={} err={:?}",
@@ -268,10 +360,26 @@ impl Session {
         Ok(())
     }
 
+    /// Send the message to the card to start authentication
+    fn start_authenticate(&mut self) -> Result<response::Message, Error> {
+        let command = self.secure_channel()?.authenticate_session()?;
+        self.send_message(command)
+    }
+
+    /// Read authenticate session message from the card
+    fn finish_authenticate_session(&mut self, response: &response::Message) -> Result<(), Error> {
+        self.secure_channel()?.finish_authenticate_session(response)
+    }
+
     /// Get the underlying channel or return an error
     fn secure_channel(&mut self) -> Result<&mut SecureChannel, Error> {
         self.secure_channel
             .as_mut()
             .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed").into())
+    }
+
+    /// Get the underlying connector used by this session
+    pub(crate) fn connector(&self) -> Connector {
+        self.connector.clone()
     }
 }

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -176,15 +176,7 @@ impl SecureChannel {
         card_challenge: Challenge,
     ) -> Self {
         let context = Context::from_challenges(host_challenge, card_challenge);
-        let enc_key = derive_key(authentication_key.enc_key(), 0b100, &context);
-        let mac_key = derive_key(authentication_key.mac_key(), 0b110, &context);
-        let rmac_key = derive_key(authentication_key.mac_key(), 0b111, &context);
-
-        let session_keys = SessionKeys {
-            enc_key,
-            mac_key,
-            rmac_key,
-        };
+        let session_keys = context.derive_keys(authentication_key);
         Self::with_session_keys(id, context, session_keys)
     }
 

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -24,9 +24,9 @@ mod cryptogram;
 mod kdf;
 mod mac;
 
+pub use self::{challenge::Challenge, context::Context};
 pub(crate) use self::{
-    challenge::{Challenge, CHALLENGE_SIZE},
-    context::Context,
+    challenge::CHALLENGE_SIZE,
     cryptogram::{Cryptogram, CRYPTOGRAM_SIZE},
     mac::Mac,
 };
@@ -35,7 +35,7 @@ use crate::{
     authentication::{self, Credentials},
     command::{self, Command},
     connector::Connector,
-    device, response,
+    device, object, response,
     serialization::deserialize,
     session::{self, ErrorKind},
 };
@@ -47,6 +47,7 @@ use aes::{
     Aes128,
 };
 use cmac::{digest::Mac as _, Cmac};
+use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -70,6 +71,42 @@ const AES_BLOCK_SIZE: usize = 16;
 type Aes128CbcEnc = cbc::Encryptor<Aes128>;
 type Aes128CbcDec = cbc::Decryptor<Aes128>;
 
+/// SCP03 AES Session Keys
+#[derive(Serialize, Deserialize)]
+pub struct SessionKeys {
+    /// Session encryption key (S-ENC)
+    pub enc_key: [u8; KEY_SIZE],
+
+    /// Session Command MAC key (S-MAC)
+    pub mac_key: [u8; KEY_SIZE],
+
+    /// Session Respose MAC key (S-RMAC)
+    pub rmac_key: [u8; KEY_SIZE],
+}
+
+impl Zeroize for SessionKeys {
+    fn zeroize(&mut self) {
+        self.enc_key.zeroize();
+        self.mac_key.zeroize();
+        self.rmac_key.zeroize();
+    }
+}
+
+#[cfg(feature = "yubihsm-auth")]
+impl From<yubikey::hsmauth::SessionKeys> for SessionKeys {
+    fn from(keys: yubikey::hsmauth::SessionKeys) -> Self {
+        let enc_key = *keys.enc_key;
+        let mac_key = *keys.mac_key;
+        let rmac_key = *keys.rmac_key;
+
+        Self {
+            enc_key,
+            mac_key,
+            rmac_key,
+        }
+    }
+}
+
 /// SCP03 Secure Channel
 pub(crate) struct SecureChannel {
     /// ID of this channel (a.k.a. session ID)
@@ -85,14 +122,8 @@ pub(crate) struct SecureChannel {
     /// Context (card + host challenges)
     context: Context,
 
-    /// Session encryption key (S-ENC)
-    enc_key: [u8; KEY_SIZE],
-
-    /// Session Command MAC key (S-MAC)
-    mac_key: [u8; KEY_SIZE],
-
-    /// Session Respose MAC key (S-RMAC)
-    rmac_key: [u8; KEY_SIZE],
+    /// Session keys
+    session_keys: SessionKeys,
 
     /// Chaining value to be included when computing MACs
     mac_chaining_value: [u8; Mac::BYTE_SIZE * 2],
@@ -107,46 +138,8 @@ impl SecureChannel {
     ) -> Result<Self, session::Error> {
         let host_challenge = Challenge::new();
 
-        let command_message = CreateSessionCommand {
-            authentication_key_id: credentials.authentication_key_id,
-            host_challenge,
-        }
-        .to_message()?;
-
-        let uuid = command_message.uuid;
-        let response_body = connector.send_message(uuid, command_message.into())?;
-        let response_message = response::Message::parse(response_body)?;
-
-        if response_message.is_err() {
-            match device::ErrorKind::from_response_message(&response_message) {
-                Some(device::ErrorKind::ObjectNotFound) => fail!(
-                    ErrorKind::AuthenticationError,
-                    "auth key not found: 0x{:04x}",
-                    credentials.authentication_key_id
-                ),
-                Some(kind) => return Err(kind.into()),
-                None => fail!(
-                    ErrorKind::ResponseError,
-                    "HSM error: {:?}",
-                    response_message.code
-                ),
-            }
-        }
-
-        if response_message.command().unwrap() != command::Code::CreateSession {
-            fail!(
-                ErrorKind::ProtocolError,
-                "command type mismatch: expected {:?}, got {:?}",
-                command::Code::CreateSession,
-                response_message.command().unwrap()
-            );
-        }
-
-        let id = response_message
-            .session_id
-            .ok_or_else(|| format_err!(ErrorKind::CreateFailed, "no session ID in response"))?;
-
-        let session_response: CreateSessionResponse = deserialize(response_message.data.as_ref())?;
+        let (id, session_response) =
+            Self::create(connector, credentials.authentication_key_id, host_challenge)?;
 
         // Derive session keys from the combination of host and card challenges.
         // If either of them are incorrect (indicating a key mismatch) it will
@@ -186,6 +179,20 @@ impl SecureChannel {
         let enc_key = derive_key(authentication_key.enc_key(), 0b100, &context);
         let mac_key = derive_key(authentication_key.mac_key(), 0b110, &context);
         let rmac_key = derive_key(authentication_key.mac_key(), 0b111, &context);
+
+        let session_keys = SessionKeys {
+            enc_key,
+            mac_key,
+            rmac_key,
+        };
+        Self::with_session_keys(id, context, session_keys)
+    }
+
+    pub(crate) fn with_session_keys(
+        id: session::Id,
+        context: Context,
+        session_keys: SessionKeys,
+    ) -> Self {
         let mac_chaining_value = [0u8; Mac::BYTE_SIZE * 2];
 
         Self {
@@ -193,11 +200,61 @@ impl SecureChannel {
             counter: 0,
             security_level: SecurityLevel::None,
             context,
-            enc_key,
-            mac_key,
-            rmac_key,
+            session_keys,
             mac_chaining_value,
         }
+    }
+
+    /// Open a SecureChannel with the HSM. This will not complete authentication.
+    ///
+    /// This will return the session id as well as the card challenge.
+    pub(crate) fn create(
+        connector: &Connector,
+        authentication_key_id: object::Id,
+        host_challenge: Challenge,
+    ) -> Result<(session::Id, CreateSessionResponse), session::Error> {
+        let command_message = CreateSessionCommand {
+            authentication_key_id, //: credentials.authentication_key_id,
+            host_challenge,
+        }
+        .to_message()?;
+
+        let uuid = command_message.uuid;
+        let response_body = connector.send_message(uuid, command_message.into())?;
+        let response_message = response::Message::parse(response_body)?;
+
+        if response_message.is_err() {
+            match device::ErrorKind::from_response_message(&response_message) {
+                Some(device::ErrorKind::ObjectNotFound) => fail!(
+                    ErrorKind::AuthenticationError,
+                    "auth key not found: 0x{:04x}",
+                    authentication_key_id
+                ),
+                Some(kind) => return Err(kind.into()),
+                None => fail!(
+                    ErrorKind::ResponseError,
+                    "HSM error: {:?}",
+                    response_message.code
+                ),
+            }
+        }
+
+        if response_message.command().unwrap() != command::Code::CreateSession {
+            fail!(
+                ErrorKind::ProtocolError,
+                "command type mismatch: expected {:?}, got {:?}",
+                command::Code::CreateSession,
+                response_message.command().unwrap()
+            );
+        }
+
+        let id = response_message
+            .session_id
+            .ok_or_else(|| format_err!(ErrorKind::CreateFailed, "no session ID in response"))?;
+
+        let session_response: CreateSessionResponse = deserialize(response_message.data.as_ref())?;
+
+        Ok((id, session_response))
     }
 
     /// Get the channel (i.e. session) ID
@@ -208,14 +265,24 @@ impl SecureChannel {
     /// Calculate the card's cryptogram for this session
     pub fn card_cryptogram(&self) -> Cryptogram {
         let mut result_bytes = Zeroizing::new([0u8; CRYPTOGRAM_SIZE]);
-        kdf::derive(&self.mac_key, 0, &self.context, result_bytes.as_mut());
+        kdf::derive(
+            &self.session_keys.mac_key,
+            0,
+            &self.context,
+            result_bytes.as_mut(),
+        );
         Cryptogram::from_slice(result_bytes.as_ref())
     }
 
     /// Calculate the host's cryptogram for this session
     pub fn host_cryptogram(&self) -> Cryptogram {
         let mut result_bytes = Zeroizing::new([0u8; CRYPTOGRAM_SIZE]);
-        kdf::derive(&self.mac_key, 1, &self.context, result_bytes.as_mut());
+        kdf::derive(
+            &self.session_keys.mac_key,
+            1,
+            &self.context,
+            result_bytes.as_mut(),
+        );
         Cryptogram::from_slice(result_bytes.as_ref())
     }
 
@@ -234,7 +301,8 @@ impl SecureChannel {
             );
         }
 
-        let mut mac = <Cmac<Aes128> as KeyInit>::new_from_slice(self.mac_key.as_ref()).unwrap();
+        let mut mac =
+            <Cmac<Aes128> as KeyInit>::new_from_slice(self.session_keys.mac_key.as_ref()).unwrap();
         mac.update(&self.mac_chaining_value);
         mac.update(&[command_type.to_u8()]);
 
@@ -299,7 +367,7 @@ impl SecureChannel {
         // Provide space at the end of the vec for the padding
         message.extend_from_slice(&[0u8; AES_BLOCK_SIZE]);
 
-        let cipher = Aes128::new_from_slice(&self.enc_key).unwrap();
+        let cipher = Aes128::new_from_slice(&self.session_keys.enc_key).unwrap();
         let icv = compute_icv(&cipher, self.counter);
         let cbc_encryptor = Aes128CbcEnc::inner_iv_init(cipher, &icv);
         let ciphertext = cbc_encryptor
@@ -316,7 +384,7 @@ impl SecureChannel {
     ) -> Result<response::Message, session::Error> {
         assert_eq!(self.security_level, SecurityLevel::Authenticated);
 
-        let cipher = Aes128::new_from_slice(&self.enc_key).unwrap();
+        let cipher = Aes128::new_from_slice(&self.session_keys.enc_key).unwrap();
         let icv = compute_icv(&cipher, self.counter);
 
         self.verify_response_mac(&encrypted_response)?;
@@ -365,7 +433,8 @@ impl SecureChannel {
             );
         }
 
-        let mut mac = <Cmac<Aes128> as KeyInit>::new_from_slice(self.rmac_key.as_ref()).unwrap();
+        let mut mac =
+            <Cmac<Aes128> as KeyInit>::new_from_slice(self.session_keys.rmac_key.as_ref()).unwrap();
         mac.update(&self.mac_chaining_value);
         mac.update(&[response.code.to_u8()]);
 
@@ -442,12 +511,12 @@ impl SecureChannel {
     ) -> Result<command::Message, session::Error> {
         assert_eq!(self.security_level, SecurityLevel::Authenticated);
 
-        let cipher = Aes128::new_from_slice(&self.enc_key).unwrap();
+        let cipher = Aes128::new_from_slice(&self.session_keys.enc_key).unwrap();
         let icv = compute_icv(&cipher, self.counter);
 
         self.verify_command_mac(&encrypted_command)?;
 
-        let cipher = Aes128::new_from_slice(&self.enc_key).unwrap();
+        let cipher = Aes128::new_from_slice(&self.session_keys.enc_key).unwrap();
         let cbc_decryptor = Aes128CbcDec::inner_iv_init(cipher, &icv);
 
         let mut command_data = encrypted_command.data;
@@ -480,7 +549,8 @@ impl SecureChannel {
             command.session_id
         );
 
-        let mut mac = <Cmac<Aes128> as KeyInit>::new_from_slice(self.mac_key.as_ref()).unwrap();
+        let mut mac =
+            <Cmac<Aes128> as KeyInit>::new_from_slice(self.session_keys.mac_key.as_ref()).unwrap();
         mac.update(&self.mac_chaining_value);
         mac.update(&[command.command_type.to_u8()]);
 
@@ -520,7 +590,7 @@ impl SecureChannel {
         // Provide space at the end of the vec for the padding
         message.extend_from_slice(&[0u8; AES_BLOCK_SIZE]);
 
-        let cipher = Aes128::new_from_slice(&self.enc_key).unwrap();
+        let cipher = Aes128::new_from_slice(&self.session_keys.enc_key).unwrap();
         let icv = compute_icv(&cipher, self.counter);
         let cbc_encryptor = Aes128CbcEnc::inner_iv_init(cipher, &icv);
 
@@ -549,7 +619,8 @@ impl SecureChannel {
         assert_eq!(self.security_level, SecurityLevel::Authenticated);
         let body = response_data.into();
 
-        let mut mac = <Cmac<Aes128> as KeyInit>::new_from_slice(self.rmac_key.as_ref()).unwrap();
+        let mut mac =
+            <Cmac<Aes128> as KeyInit>::new_from_slice(self.session_keys.rmac_key.as_ref()).unwrap();
         mac.update(&self.mac_chaining_value);
         mac.update(&[code.to_u8()]);
 
@@ -585,9 +656,7 @@ impl SecureChannel {
     /// Terminate the session
     fn terminate(&mut self) {
         self.security_level = SecurityLevel::Terminated;
-        self.enc_key.zeroize();
-        self.mac_key.zeroize();
-        self.rmac_key.zeroize();
+        self.session_keys.zeroize();
     }
 }
 

--- a/src/session/securechannel/challenge.rs
+++ b/src/session/securechannel/challenge.rs
@@ -3,6 +3,9 @@
 use rand_core::Rng;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "yubihsm-auth")]
+use crate::session::error::{Error, ErrorKind};
+
 /// Size of a challenge message
 pub const CHALLENGE_SIZE: usize = 8;
 
@@ -35,5 +38,42 @@ impl Challenge {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn as_slice(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Creates `Challenge` from a `yubikey::hsmauth::Challenge`.
+    ///
+    /// `YubiKey` firmware 5.4.3 will generate an empty challenge, this will
+    /// generate one from RNG if we're provided an empty challenge
+    // Note(baloo): because of the side-effect described above, this is not
+    // made a regular From<yubikey::hsmauth::Challenge>.
+    #[cfg(feature = "yubihsm-auth")]
+    pub fn from_yubikey_challenge(yc: yubikey::hsmauth::Challenge) -> Self {
+        if yc.is_empty() {
+            Self::new()
+        } else {
+            let mut challenge = [0u8; CHALLENGE_SIZE];
+            challenge.copy_from_slice(yc.as_slice());
+            Challenge(challenge)
+        }
+    }
+}
+
+#[cfg(feature = "yubihsm-auth")]
+impl TryFrom<Challenge> for yubikey::hsmauth::Challenge {
+    type Error = Error;
+
+    fn try_from(c: Challenge) -> Result<Self, Error> {
+        let mut challenge = yubikey::hsmauth::Challenge::default();
+        challenge
+            .copy_from_slice(c.as_slice())
+            .map_err(|e| Error::from(ErrorKind::ProtocolError.context(e)))?;
+
+        Ok(challenge)
+    }
+}
+
+impl Default for Challenge {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/session/securechannel/context.rs
+++ b/src/session/securechannel/context.rs
@@ -1,6 +1,7 @@
 //! Derivation context (i.e. concatenated challenges)
 
-use super::{Challenge, CHALLENGE_SIZE};
+use super::{derive_key, Challenge, SessionKeys, CHALLENGE_SIZE};
+use crate::authentication;
 
 /// Size of a session context
 const CONTEXT_SIZE: usize = CHALLENGE_SIZE * 2;
@@ -20,6 +21,19 @@ impl Context {
     /// Borrow the context value as a slice
     pub fn as_slice(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Derive session keys from context and authentication key
+    pub fn derive_keys(&self, authentication_key: &authentication::Key) -> SessionKeys {
+        let enc_key = derive_key(authentication_key.enc_key(), 0b100, self);
+        let mac_key = derive_key(authentication_key.mac_key(), 0b110, self);
+        let rmac_key = derive_key(authentication_key.mac_key(), 0b111, self);
+
+        SessionKeys {
+            enc_key,
+            mac_key,
+            rmac_key,
+        }
     }
 }
 

--- a/src/session/securechannel/context.rs
+++ b/src/session/securechannel/context.rs
@@ -22,3 +22,10 @@ impl Context {
         &self.0
     }
 }
+
+#[cfg(feature = "yubihsm-auth")]
+impl From<Context> for yubikey::hsmauth::Context {
+    fn from(context: Context) -> Self {
+        Self::from_buf(context.0)
+    }
+}


### PR DESCRIPTION
This allows to split the derivation of session keys with the HSM on a separate process with reduced lifespan/more restricted feature set.