### PR TITLE
Add error variant for non-existent authentication key.

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -18,6 +18,10 @@ pub enum ErrorKind {
     #[error("authentication failed")]
     AuthenticationError,
 
+    /// Authentication key doesn't exist
+    #[error("authentication key doesn't exist")]
+    AuthenticationKeyError,
+
     /// Session is closed
     #[error("session closed")]
     ClosedSessionError,
@@ -73,6 +77,7 @@ impl From<session::Error> for Error {
     fn from(err: session::Error) -> Self {
         let kind = match err.kind() {
             session::ErrorKind::AuthenticationError => ErrorKind::AuthenticationError,
+            session::ErrorKind::AuthenticationKeyError => ErrorKind::AuthenticationKeyError,
             session::ErrorKind::ClosedError => ErrorKind::ClosedSessionError,
             session::ErrorKind::CreateFailed => ErrorKind::CreateFailed,
             session::ErrorKind::DeviceError => ErrorKind::DeviceError,

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -14,6 +14,10 @@ pub enum ErrorKind {
     #[error("authentication failed")]
     AuthenticationError,
 
+    /// Authentication key doesn't exist
+    #[error("authentication key doesn't exist")]
+    AuthenticationKeyError,
+
     /// Session is closed
     #[error("session closed")]
     ClosedError,

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -119,7 +119,7 @@ impl SecureChannel {
         if response_message.is_err() {
             match device::ErrorKind::from_response_message(&response_message) {
                 Some(device::ErrorKind::ObjectNotFound) => fail!(
-                    ErrorKind::AuthenticationError,
+                    ErrorKind::AuthenticationKeyError,
                     "auth key not found: 0x{:04x}",
                     credentials.authentication_key_id
                 ),


### PR DESCRIPTION
The `AuthenticationError` variant was used to cover errors caused by both an invalid password and the use of an auth id that doesn't exist in the YubiHSM. This commit adds a new variant to allow the consumer to differentiate the two.