### PR TITLE
rsa(pss): check message size post hashing

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1049,16 +1049,16 @@ impl Client {
         key_id: object::Id,
         data: &[u8],
     ) -> Result<rsa::pss::Signature, Error> {
-        ensure!(
-            data.len() < rsa::pss::MAX_MESSAGE_SIZE,
-            ErrorKind::ProtocolError,
-            "message too large to be signed (max: {})",
-            rsa::pss::MAX_MESSAGE_SIZE
-        );
-
         let mut hasher = S::new();
         hasher.update(data);
         let digest = hasher.finalize();
+
+        ensure!(
+            digest.len() < rsa::pss::MAX_MESSAGE_SIZE,
+            ErrorKind::ProtocolError,
+            "digest too large to be signed (max: {})",
+            rsa::pss::MAX_MESSAGE_SIZE
+        );
 
         Ok(self
             .send_command(SignPssCommand {


### PR DESCRIPTION
The limit to what pss can sign only applies to what is being signed. Only the hash is being signed.

Arguably, the check could probably be dropped as it's unlikely the digest is ever going over 0xFFFF of length.