### PR TITLE
Improve the documentation of the client module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - 1.85.0 # MSRV
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -36,7 +36,7 @@ jobs:
           - stable
           - 1.85.0 # MSRV
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -57,10 +57,26 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        with:
+          command: doc
+          args: --no-deps --all-features
+
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85.0 # pinned to prevent CI breakages

--- a/src/wrap/info.rs
+++ b/src/wrap/info.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Information about an object
 ///
-/// This is a wrap-specific version of [`object::Info']. It does not carry any
+/// This is a wrap-specific version of [`object::Info`]. It does not carry any
 /// delegated_capabilities.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Info {


### PR DESCRIPTION
This PR:
- updates links in the client module to latest documentation (to save one click per link),
- updates references to use short markdown syntax
- adds nicer warning sections
- adds a CI task to check for documentation errors
- updates all checkout steps to use latest version
- I've also moved the `#[allow(clippy::too_many_arguments)]` to respective functions to limit the lint suppression

Sorry for bundling it all together but it was kind-of related :sweat_smile: 

I thought I'll easily take a pass at all items but then this single module sunk a bit more time than I anticipated :sweat: 

:wave: 