### PR TITLE
Fix propagating permission errors in `Client::reset_device`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -809,9 +809,15 @@ impl Client {
     pub fn reset_device(&self) -> Result<(), Error> {
         let mut session = self.session()?;
 
-        // TODO: handle potential errors that occur when resetting
-        if let Err(e) = session.send_command(&ResetDeviceCommand {}) {
-            debug!("error sending reset command: {}", e);
+        let result = session.send_command(&ResetDeviceCommand {});
+        if let Err(e) = &result {
+            if *e.kind() == session::ErrorKind::ProtocolError {
+                // real devices can send protocol errors when the request has been accepted
+                debug!("error sending reset command: {}", e);
+            } else {
+                // other errors, such as insufficient permissions, should be propagated
+                result?;
+            }
         }
 
         // Resetting the HSM invalidates our session


### PR DESCRIPTION
When a real device receives a valid request to reset itself it won't send a valid reply and the request will return a `ProtocolError` (`protocol error: protocol error: I/O error: failed to fill whole buffer`). The original code suppressed errors since the request has been correctly understood by the device. Unfortunately this suppressed real errors, when the request has not been processed, e.g. due to insufficient permissions.

This PR adjusts the check to filter out only protocol errors and propagate all others. I've tested it on a real device in both happy path (the device has been reset to factory settings) and failing path (insufficient permissions).

Closes: https://github.com/iqlusioninc/yubihsm.rs/issues/619