### PR TITLE
Add `verify_log_entries` function for checking log integrity

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -4,7 +4,7 @@ pub(crate) mod commands;
 mod error;
 
 pub use self::{
-    commands::{LogDigest, LogEntries, LogEntry},
+    commands::{verify_log_entries, LogDigest, LogEntries, LogEntry},
     error::{Error, ErrorKind},
 };
 

--- a/src/audit/commands.rs
+++ b/src/audit/commands.rs
@@ -5,5 +5,5 @@ mod get_option;
 mod set_log_index;
 mod set_option;
 
-pub use self::get_log_entries::{LogDigest, LogEntries, LogEntry};
+pub use self::get_log_entries::{verify_log_entries, LogDigest, LogEntries, LogEntry};
 pub(crate) use self::{get_log_entries::*, get_option::*, set_log_index::*, set_option::*};

--- a/src/audit/commands/get_log_entries.rs
+++ b/src/audit/commands/get_log_entries.rs
@@ -9,6 +9,7 @@ use crate::{
     serialization::{self, serialize},
 };
 use serde::{ser, Deserialize, Serialize};
+use sha2::Digest as _;
 use std::fmt::{self, Debug};
 
 /// Request parameters for `command::get_log_entries`
@@ -124,6 +125,33 @@ impl Serialize for AuditResponseCode {
     }
 }
 
+/// Verify log entries for consistency.
+///
+/// Checks if `entries_to_verify` are correctly derived from the `root` entry as described in [the documentation].
+/// The root entry is usually the device initialization message but it is not strictly necessary.
+///
+/// Returns `Ok(true)` if the log entry is consistent, `Ok(false)` if not, and `Err(...)` on serialization errors.
+///
+/// [the documentation]: https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#hsm2-cmd-get-log-entries-label
+pub fn verify_log_entries(
+    root: &LogEntry,
+    entries_to_verify: &[LogEntry],
+) -> Result<bool, serialization::Error> {
+    let mut hasher = sha2::Sha256::new();
+    let mut previous_digest = root.digest.0;
+    for entry in entries_to_verify {
+        hasher.update(entry.digest_payload()?);
+        hasher.update(previous_digest);
+
+        let trunc_digest = &hasher.finalize_reset()[..16];
+        if trunc_digest != entry.digest.0 {
+            return Ok(false);
+        }
+        previous_digest.copy_from_slice(trunc_digest);
+    }
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,5 +209,51 @@ mod tests {
             serialize(&entry).expect("serialize the entry back"),
             &payload
         );
+    }
+
+    #[test]
+    fn serialize_device_boot_entry() {
+        let device_boot_msg: &[u8] = &[
+            0, 2, 0, 0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 237, 217, 180, 224, 195, 140, 79,
+            126, 197, 15, 5, 112, 145, 241, 47, 206,
+        ];
+        let entry: LogEntry = deserialize(device_boot_msg).expect("Parse log entry");
+        assert_eq!(
+            entry,
+            LogEntry {
+                item: 2,
+                cmd: command::Code::Unknown,
+                length: 0,
+                session_key: 65535,
+                target_key: 0,
+                second_key: 0,
+                result: AuditResponseCode(response::Code::DeviceOk),
+                tick: 0,
+                digest: LogDigest([
+                    0xed, 0xd9, 0xb4, 0xe0, 0xc3, 0x8c, 0x4f, 0x7e, 0xc5, 0x0f, 0x05, 0x70, 0x91,
+                    0xf1, 0x2f, 0xce
+                ])
+            }
+        );
+    }
+
+    #[test]
+    fn verify_log() {
+        let log: LogEntries = deserialize(&[
+            0, 0, 0, 0, 5, 0, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 16, 57, 193, 231, 53, 39, 161, 48, 106, 91, 222, 241, 111, 218, 230, 186, 0, 2, 0,
+            0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77, 6, 54, 133, 12, 128, 156, 82, 145, 139,
+            111, 177, 109, 100, 204, 5, 0, 3, 106, 0, 14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1, 6,
+            202, 0, 137, 24, 52, 154, 17, 142, 18, 48, 153, 220, 202, 91, 172, 147, 0, 4, 106, 0,
+            14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1, 10, 253, 255, 178, 231, 56, 29, 160, 88, 146,
+            181, 192, 29, 142, 45, 44, 215, 0, 5, 106, 0, 14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1,
+            13, 83, 130, 159, 15, 119, 58, 142, 25, 94, 111, 244, 153, 172, 98, 117, 239,
+        ])
+        .expect("log entries should be ok");
+
+        let root = &log.entries[0];
+        let entries_to_verify = &log.entries[1..];
+
+        verify_log_entries(root, entries_to_verify).expect("verification to succeed");
     }
 }

--- a/src/audit/commands/get_log_entries.rs
+++ b/src/audit/commands/get_log_entries.rs
@@ -237,23 +237,69 @@ mod tests {
         );
     }
 
+    /// A five-entry log read from a device: boot entry followed by four
+    /// command entries, each chaining to the previous digest.
+    static SAMPLE_LOG: &[u8] = &[
+        0, 0, 0, 0, 5, 0, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        16, 57, 193, 231, 53, 39, 161, 48, 106, 91, 222, 241, 111, 218, 230, 186, 0, 2, 0, 0, 0,
+        255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77, 6, 54, 133, 12, 128, 156, 82, 145, 139, 111, 177,
+        109, 100, 204, 5, 0, 3, 106, 0, 14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1, 6, 202, 0, 137, 24,
+        52, 154, 17, 142, 18, 48, 153, 220, 202, 91, 172, 147, 0, 4, 106, 0, 14, 0, 1, 0, 7, 255,
+        255, 234, 0, 0, 1, 10, 253, 255, 178, 231, 56, 29, 160, 88, 146, 181, 192, 29, 142, 45, 44,
+        215, 0, 5, 106, 0, 14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1, 13, 83, 130, 159, 15, 119, 58,
+        142, 25, 94, 111, 244, 153, 172, 98, 117, 239,
+    ];
+
     #[test]
     fn verify_log() {
-        let log: LogEntries = deserialize(&[
-            0, 0, 0, 0, 5, 0, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 16, 57, 193, 231, 53, 39, 161, 48, 106, 91, 222, 241, 111, 218, 230, 186, 0, 2, 0,
-            0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77, 6, 54, 133, 12, 128, 156, 82, 145, 139,
-            111, 177, 109, 100, 204, 5, 0, 3, 106, 0, 14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1, 6,
-            202, 0, 137, 24, 52, 154, 17, 142, 18, 48, 153, 220, 202, 91, 172, 147, 0, 4, 106, 0,
-            14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1, 10, 253, 255, 178, 231, 56, 29, 160, 88, 146,
-            181, 192, 29, 142, 45, 44, 215, 0, 5, 106, 0, 14, 0, 1, 0, 7, 255, 255, 234, 0, 0, 1,
-            13, 83, 130, 159, 15, 119, 58, 142, 25, 94, 111, 244, 153, 172, 98, 117, 239,
-        ])
-        .expect("log entries should be ok");
+        let log: LogEntries = deserialize(SAMPLE_LOG).expect("log entries should be ok");
 
         let root = &log.entries[0];
         let entries_to_verify = &log.entries[1..];
 
-        verify_log_entries(root, entries_to_verify).expect("verification to succeed");
+        assert!(
+            verify_log_entries(root, entries_to_verify).expect("verification should not error"),
+            "a known-good log chain must verify"
+        );
+    }
+
+    /// A tampered chain must not verify.
+    ///
+    /// Without this, `verify_log_entries` could return `Ok(false)` for every
+    /// input and the positive test above would still pass -- `expect` only
+    /// unwraps the `Result`, and the failure signal is the `bool` inside it.
+    #[test]
+    fn verify_log_detects_tampering() {
+        let mut log: LogEntries = deserialize(SAMPLE_LOG).expect("log entries should be ok");
+
+        // Flip a bit in the digest of the last entry, as a device returning a
+        // doctored log would.
+        let last = log.entries.len() - 1;
+        log.entries[last].digest.0[0] ^= 0x01;
+
+        let root = &log.entries[0];
+        let entries_to_verify = &log.entries[1..];
+
+        assert!(
+            !verify_log_entries(root, entries_to_verify).expect("verification should not error"),
+            "a tampered log chain must not verify"
+        );
+    }
+
+    /// Tampering with the payload rather than the digest must also be caught.
+    #[test]
+    fn verify_log_detects_payload_tampering() {
+        let mut log: LogEntries = deserialize(SAMPLE_LOG).expect("log entries should be ok");
+
+        let last = log.entries.len() - 1;
+        log.entries[last].target_key ^= 0x0001;
+
+        let root = &log.entries[0];
+        let entries_to_verify = &log.entries[1..];
+
+        assert!(
+            !verify_log_entries(root, entries_to_verify).expect("verification should not error"),
+            "a log chain with a doctored entry must not verify"
+        );
     }
 }


### PR DESCRIPTION
This function implements log consistency checks, as described in Yubico documentation.

There are a couple of variations of what could be tweaked here (e.g. in case of errors returning the first "broken" log entry, and having `Result<()`, instead of `Result<bool`, as well as constant-time comparisons of the digests).

Happy to hear your input! :wave: 

Relevant issue: https://github.com/iqlusioninc/yubihsm.rs/issues/670