### PR TITLE
mockhsm: implement capabilities check before resetting device

### DIFF
--- a/src/mockhsm/session.rs
+++ b/src/mockhsm/session.rs
@@ -8,6 +8,7 @@ use crate::{
         securechannel::{Challenge, Cryptogram, SecureChannel},
         Id,
     },
+    Capability,
 };
 
 /// Session with the `MockHsm`
@@ -20,15 +21,24 @@ pub(crate) struct HsmSession {
 
     /// Encrypted channel
     pub channel: SecureChannel,
+
+    /// Authentication key's capabilities
+    pub auth_capabilities: Capability,
 }
 
 impl HsmSession {
     /// Create a new session
-    pub fn new(id: Id, card_challenge: Challenge, channel: SecureChannel) -> Self {
+    pub fn new(
+        id: Id,
+        card_challenge: Challenge,
+        channel: SecureChannel,
+        auth_capabilities: Capability,
+    ) -> Self {
         Self {
             id,
             card_challenge,
             channel,
+            auth_capabilities,
         }
     }
 

--- a/tests/command/reset_device.rs
+++ b/tests/command/reset_device.rs
@@ -1,6 +1,80 @@
+use yubihsm::Client;
+
 /// Reset the YubiHSM 2 to a factory default state
 #[test]
 fn reset_test() {
     let client = crate::get_hsm_client();
     client.reset_device().unwrap();
+}
+
+#[test]
+#[cfg(feature = "mockhsm")]
+fn reset_no_auth() {
+    use yubihsm::{authentication, Capability, Credentials, Domain};
+
+    use crate::create_mockhsm_connector;
+
+    let authentication_key = authentication::Key::random();
+
+    let client = Client::open(create_mockhsm_connector(), Default::default(), true).unwrap();
+    client
+        .put_authentication_key(
+            2,
+            Default::default(),
+            Domain::DOM1,
+            // this key does NOT have RESET_DEVICE capability
+            Capability::empty(),
+            Capability::empty(),
+            yubihsm::authentication::Algorithm::YubicoAes,
+            authentication_key.clone(),
+        )
+        .unwrap();
+
+    let client = Client::open(
+        // reuse the same mock hsm so that the previous key stays in memory
+        client.connector().clone(),
+        Credentials::new(2, authentication_key),
+        true,
+    )
+    .unwrap();
+    assert!(
+        client.reset_device().is_err(),
+        "resetting device should fail if authentication key doesn't have correct permissions"
+    );
+}
+
+#[test]
+#[cfg(feature = "mockhsm")]
+fn reset_with_auth() {
+    use yubihsm::{authentication, Capability, Credentials, Domain};
+
+    use crate::create_mockhsm_connector;
+
+    let authentication_key = authentication::Key::random();
+
+    let client = Client::open(create_mockhsm_connector(), Default::default(), true).unwrap();
+    client
+        .put_authentication_key(
+            2,
+            Default::default(),
+            Domain::DOM1,
+            // this key has RESET_DEVICE capability
+            Capability::RESET_DEVICE,
+            Capability::empty(),
+            yubihsm::authentication::Algorithm::YubicoAes,
+            authentication_key.clone(),
+        )
+        .unwrap();
+
+    let client = Client::open(
+        // reuse the same mock hsm so that the previous key stays in memory
+        client.connector().clone(),
+        Credentials::new(2, authentication_key),
+        true,
+    )
+    .unwrap();
+    assert!(
+        client.reset_device().is_ok(),
+        "resetting device should succeed with correct capabilities"
+    );
 }


### PR DESCRIPTION
Previously no authentication key capabilities have been checked.
This patch adds reading capabilities when opening the session and checking
them before issuing device reset.

Depends on https://github.com/iqlusioninc/yubihsm.rs/pull/620