### PR TITLE
command: handle message serialization failures

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -11,7 +11,7 @@ pub use self::{
 };
 
 pub(crate) use self::message::Message;
-use crate::{response::Response, serialization::serialize};
+use crate::{response::Response, serialization::serialize, session};
 use serde::{de::DeserializeOwned, ser::Serialize};
 
 /// Maximum size of a message sent to/from the YubiHSM
@@ -28,10 +28,8 @@ pub(crate) trait Command: Serialize + DeserializeOwned + Sized {
 
     /// Command ID for this command
     const COMMAND_CODE: Code = Self::ResponseType::COMMAND_CODE;
-}
 
-impl<C: Command> From<&C> for Message {
-    fn from(command: &C) -> Message {
-        Self::create(C::COMMAND_CODE, serialize(command).unwrap()).unwrap()
+    fn to_message(&self) -> Result<Message, session::Error> {
+        Message::create(Self::COMMAND_CODE, serialize(self)?)
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -146,18 +146,18 @@ impl Session {
         &mut self,
         command: &C,
     ) -> Result<C::ResponseType, Error> {
-        let plaintext_cmd = command::Message::from(command);
-        let cmd_type = plaintext_cmd.command_type;
+        let plaintext_msg = command.to_message()?;
+        let cmd_type = plaintext_msg.command_type;
 
-        let encrypted_cmd = self
+        let encrypted_msg = self
             .secure_channel()?
-            .encrypt_command(plaintext_cmd)
+            .encrypt_command(plaintext_msg)
             .inspect_err(|_| {
                 // Abort the session in the event of any cryptographic errors
                 self.abort();
             })?;
 
-        let uuid = encrypted_cmd.uuid;
+        let uuid = encrypted_msg.uuid;
         session_debug!(
             self,
             "n={} uuid={} cmd={:?}",
@@ -166,7 +166,7 @@ impl Session {
             C::COMMAND_CODE
         );
 
-        let encrypted_response = self.send_message(encrypted_cmd)?;
+        let encrypted_response = self.send_message(encrypted_msg)?;
 
         let response = self
             .secure_channel()?

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -33,7 +33,7 @@ pub(crate) use self::{
 use super::commands::{CreateSessionCommand, CreateSessionResponse};
 use crate::{
     authentication::{self, Credentials},
-    command,
+    command::{self, Command},
     connector::Connector,
     device, response,
     serialization::deserialize,
@@ -107,10 +107,11 @@ impl SecureChannel {
     ) -> Result<Self, session::Error> {
         let host_challenge = Challenge::new();
 
-        let command_message = command::Message::from(&CreateSessionCommand {
+        let command_message = CreateSessionCommand {
             authentication_key_id: credentials.authentication_key_id,
             host_challenge,
-        });
+        }
+        .to_message()?;
 
         let uuid = command_message.uuid;
         let response_body = connector.send_message(uuid, command_message.into())?;


### PR DESCRIPTION
Converting `Command` to `Message` previously used a `From` impl which called `unwrap` internally.

This replaces it with a fallible `Command::to_message` method which avoids panicking on serialization errors.