### PR TITLE
Fix wrong object length in wrapped RSA keys in MockHSM

### DIFF
--- a/src/mockhsm/object/payload.rs
+++ b/src/mockhsm/object/payload.rs
@@ -9,7 +9,10 @@ use ecdsa::{
 };
 use ed25519_dalek as ed25519;
 use rand_core::RngCore;
-use rsa::{traits::PublicKeyParts, BoxedUint};
+use rsa::{
+    traits::{PrivateKeyParts as _, PublicKeyParts},
+    BoxedUint,
+};
 
 /// Loaded instances of a cryptographic primitives in the MockHsm
 #[derive(Debug)]
@@ -191,7 +194,21 @@ impl Payload {
                 <<p521::NistP521 as DigestAlgorithm>::Digest as OutputSizeUser>::OutputSize::USIZE
             }
             Payload::Ed25519Key(_) => ed25519::SECRET_KEY_LENGTH,
-            Payload::RsaKey(k) => k.size(),
+            Payload::RsaKey(key) => {
+                let primes = key.primes();
+
+                let expectation =
+                    "invariant violation: we already precomputed the values, they should be populated";
+
+                primes.iter().map(|prime| prime.to_be_bytes().len()).sum::<usize>() +
+
+                // Unwrap here is okay, we have ownership of the key and we already precomputed the values.
+                key.dp().expect(expectation).to_be_bytes().len() +
+                key.dq().expect(expectation).to_be_bytes().len() +
+                // TODO: the second unwrap for int -> uint conversion is unfortunate.
+                key.qinv().expect(expectation).retrieve().to_be_bytes().len() +
+                key.n().to_be_bytes().len()
+            }
             Payload::HmacKey(_, ref data) => data.len(),
             Payload::Opaque(_, ref data) => data.len(),
             Payload::WrapKey(_, ref data) => data.len(),

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -2,6 +2,7 @@ use crate::{
     clear_test_key_slot, test_vectors::AESCCM_TEST_VECTORS, TEST_DOMAINS, TEST_EXPORTED_KEY_ID,
     TEST_EXPORTED_KEY_LABEL, TEST_KEY_ID, TEST_KEY_LABEL,
 };
+use rsa::RsaPrivateKey;
 use yubihsm::{asymmetric, object, wrap, Capability};
 
 /// Test wrap key workflow using randomly generated keys
@@ -49,6 +50,14 @@ fn wrap_key_test() {
     let wrap_data = client
         .export_wrapped(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
         .unwrap_or_else(|err| panic!("error exporting key: {err}"));
+
+    let wrap_key = wrap::Key::from_bytes(TEST_KEY_ID, AESCCM_TEST_VECTORS[0].key).unwrap();
+
+    let plaintext = wrap_data
+        .decrypt(&wrap_key)
+        .expect("failed to decrypt the wrapped key");
+
+    assert_eq!(plaintext.object_info.length as usize, plaintext.data.len());
 
     // Delete the object from the HSM prior to re-importing it
     assert!(client
@@ -129,6 +138,8 @@ fn wrap_deserialize() {
         .decrypt(&wrap_key)
         .expect("failed to decrypt the wrapped key");
 
+    assert_eq!(plaintext.object_info.length as usize, plaintext.data.len());
+
     let private_key: p256::SecretKey = plaintext
         .ecdsa()
         .expect("Object did not contain a NistP256 object");
@@ -140,6 +151,73 @@ fn wrap_deserialize() {
             .unwrap_or_else(|err| panic!("error getting public key: {err}"))
             .ecdsa::<p256::NistP256>()
             .expect("public key was not a NistP256 object"),
+        public_key
+    );
+}
+
+#[test]
+fn wrap_deserialize_rsa() {
+    let client = crate::get_hsm_client();
+    let algorithm = wrap::Algorithm::Aes128Ccm;
+    let capabilities = Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED;
+    let delegated_capabilities = Capability::all();
+
+    clear_test_key_slot(&client, object::Type::WrapKey);
+
+    let key_id = client
+        .put_wrap_key(
+            TEST_KEY_ID,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            capabilities,
+            delegated_capabilities,
+            algorithm,
+            AESCCM_TEST_VECTORS[0].key,
+        )
+        .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
+
+    assert_eq!(key_id, TEST_KEY_ID);
+
+    // Create a key to export
+    let exported_key_type = object::Type::AsymmetricKey;
+    let exported_key_capabilities = Capability::SIGN_PKCS | Capability::EXPORTABLE_UNDER_WRAP;
+    let exported_key_algorithm = asymmetric::Algorithm::Rsa2048;
+
+    let _ = client.delete_object(TEST_EXPORTED_KEY_ID, exported_key_type);
+
+    client
+        .generate_asymmetric_key(
+            TEST_EXPORTED_KEY_ID,
+            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            exported_key_capabilities,
+            exported_key_algorithm,
+        )
+        .unwrap_or_else(|err| panic!("error generating asymmetric key: {err}"));
+
+    let wrap_data = client
+        .export_wrapped(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
+        .unwrap_or_else(|err| panic!("error exporting key: {err}"));
+
+    let wrap_key = wrap::Key::from_bytes(TEST_KEY_ID, AESCCM_TEST_VECTORS[0].key).unwrap();
+
+    let plaintext = wrap_data
+        .decrypt(&wrap_key)
+        .expect("failed to decrypt the wrapped key");
+
+    assert_eq!(plaintext.object_info.length as usize, plaintext.data.len());
+
+    let private_key: RsaPrivateKey = plaintext
+        .rsa()
+        .expect("Object did not contain a valid rsa object");
+    let public_key = private_key.as_public_key();
+
+    assert_eq!(
+        &client
+            .get_public_key(TEST_EXPORTED_KEY_ID)
+            .unwrap_or_else(|err| panic!("error getting public key: {err}"))
+            .rsa()
+            .expect("public key was not the expected RSA key"),
         public_key
     );
 }


### PR DESCRIPTION
Previously RSA keys reported just the key size as the object length but during export more data is wrapped.

This patch adjusts the calculation of the length to include the complete length of the byte representation.

Test has been added to verify that the length is correctly set. Other tests has been also extended to check this property for other key types.

I've taken the code from `Plaintext::from_rsa` which correctly exports RSA keys (but this function is unused during wrap exports).

Sadly there's no way to return errors here, nor invoke `key.precompute()`, the same applies to when the key is generated (although the test works "on my machine" :wink:).

Happy to hear how this could be improved! :wave: 