### PR TITLE
wrap: fixup ecdsa serialization

### DIFF
--- a/src/asymmetric/algorithm.rs
+++ b/src/asymmetric/algorithm.rs
@@ -97,6 +97,21 @@ impl Algorithm {
             Algorithm::Rsa2048 | Algorithm::Rsa3072 | Algorithm::Rsa4096
         )
     }
+
+    /// Returns true if the algorithm is an elliptic curve
+    pub fn is_ec(self) -> bool {
+        matches!(
+            self,
+            Algorithm::EcP224
+                | Algorithm::EcP256
+                | Algorithm::EcP384
+                | Algorithm::EcP521
+                | Algorithm::EcK256
+                | Algorithm::EcBp256
+                | Algorithm::EcBp384
+                | Algorithm::EcBp512
+        )
+    }
 }
 
 impl_algorithm_serializers!(Algorithm);

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -328,10 +328,41 @@ impl Objects {
             Origin::WrappedGenerated | Origin::WrappedImported => (),
         }
 
+        macro_rules! serialize_ec {
+            ($curve:ty) => {{
+                use ecdsa::elliptic_curve::point::AffineCoordinates;
+
+                let key = ecdsa::elliptic_curve::SecretKey::<$curve>::from_slice(
+                    &object_to_wrap.payload.to_bytes(),
+                )
+                .unwrap();
+
+                let public_key = key.public_key();
+                let public_key = public_key.as_affine();
+
+                let mut data = key.to_bytes().as_slice().to_vec();
+                data.extend_from_slice(public_key.x().as_slice());
+                data.extend_from_slice(public_key.y().as_slice());
+
+                data
+            }};
+        }
+
+        let data = match object_info.algorithm {
+            Algorithm::Asymmetric(asymmetric::Algorithm::EcP256) => serialize_ec!(p256::NistP256),
+            Algorithm::Asymmetric(asymmetric::Algorithm::EcP384) => serialize_ec!(p384::NistP384),
+            Algorithm::Asymmetric(asymmetric::Algorithm::EcP521) => serialize_ec!(p521::NistP521),
+            Algorithm::Asymmetric(asymmetric::Algorithm::EcK256) => serialize_ec!(k256::Secp256k1),
+            _other => object_to_wrap.payload.to_bytes(),
+        };
+
+        let mut object_info: wrap::Info = object_info.into();
+        object_info.length = data.len() as u16;
+
         let mut wrapped_object = serialize(&WrappedObject {
             alg_id: wrap_key.algorithm(),
-            object_info: object_info.into(),
-            data: object_to_wrap.payload.to_bytes(),
+            object_info,
+            data,
         })
         .unwrap();
 
@@ -366,6 +397,10 @@ impl Objects {
                 //  - qinv  -/
                 //
                 //  We can rebuild the key from the primes and we'll just discard the internal state here
+                &unwrapped_object.data[..alg.key_len()],
+            ),
+            Algorithm::Asymmetric(alg) if alg.is_ec() => Payload::new(
+                unwrapped_object.object_info.algorithm,
                 &unwrapped_object.data[..alg.key_len()],
             ),
             _ => Payload::new(

--- a/src/mockhsm/object/payload.rs
+++ b/src/mockhsm/object/payload.rs
@@ -51,24 +51,59 @@ pub(crate) enum Payload {
 impl Payload {
     /// Create a new payload from the given algorithm and data
     pub fn new(algorithm: Algorithm, data: &[u8]) -> Self {
+        // A payload for an EC key may have only the private key (put_asymmetric_key), or the
+        // private key and the "internal representation" for wrapped keys, which, in case of the EC, is going to be
+        // the x/y coordinates.
+        //
+        // We will accept the data to be either format (although it should be only the first in the
+        // the put_asymmetric and only the latter in the import_wrapped, but ...)
+        macro_rules! ensure_ec_len {
+            ($data: ident, $curve: ty) => {
+                assert!(
+                    $data.len() == (FieldBytesSize::<$curve>::USIZE)
+                        || $data.len() == (FieldBytesSize::<$curve>::USIZE * 3)
+                );
+            };
+        }
+
         match algorithm {
             Algorithm::Wrap(alg) => Payload::WrapKey(alg, data.into()),
             Algorithm::Asymmetric(asymmetric_alg) => match asymmetric_alg {
                 asymmetric::Algorithm::EcP256 => {
-                    assert_eq!(data.len(), 32);
-                    Payload::EcdsaNistP256(p256::SecretKey::from_slice(data).unwrap())
+                    ensure_ec_len!(data, p256::NistP256);
+                    Payload::EcdsaNistP256(
+                        p256::SecretKey::from_slice(
+                            &data[..FieldBytesSize::<p256::NistP256>::USIZE],
+                        )
+                        .unwrap(),
+                    )
                 }
                 asymmetric::Algorithm::EcK256 => {
-                    assert_eq!(data.len(), 32);
-                    Payload::EcdsaSecp256k1(k256::SecretKey::from_slice(data).unwrap())
+                    ensure_ec_len!(data, k256::Secp256k1);
+                    Payload::EcdsaSecp256k1(
+                        k256::SecretKey::from_slice(
+                            &data[..FieldBytesSize::<k256::Secp256k1>::USIZE],
+                        )
+                        .unwrap(),
+                    )
                 }
                 asymmetric::Algorithm::EcP384 => {
-                    assert_eq!(data.len(), FieldBytesSize::<p384::NistP384>::USIZE);
-                    Payload::EcdsaNistP384(p384::SecretKey::from_slice(data).unwrap())
+                    ensure_ec_len!(data, p384::NistP384);
+                    Payload::EcdsaNistP384(
+                        p384::SecretKey::from_slice(
+                            &data[..FieldBytesSize::<p384::NistP384>::USIZE],
+                        )
+                        .unwrap(),
+                    )
                 }
                 asymmetric::Algorithm::EcP521 => {
-                    assert_eq!(data.len(), FieldBytesSize::<p521::NistP521>::USIZE);
-                    Payload::EcdsaNistP521(p521::SecretKey::from_slice(data).unwrap())
+                    ensure_ec_len!(data, p521::NistP521);
+                    Payload::EcdsaNistP521(
+                        p521::SecretKey::from_slice(
+                            &data[..FieldBytesSize::<p521::NistP521>::USIZE],
+                        )
+                        .unwrap(),
+                    )
                 }
 
                 asymmetric::Algorithm::Ed25519 => {

--- a/src/wrap/message.rs
+++ b/src/wrap/message.rs
@@ -13,8 +13,9 @@ use aes::cipher::typenum::Unsigned;
 use ccm::aead::Aead;
 use ecdsa::{
     elliptic_curve::{
+        point::AffineCoordinates,
         sec1::{ModulusSize, ValidatePublicKey},
-        FieldBytesSize, SecretKey,
+        CurveArithmetic, FieldBytesSize, SecretKey,
     },
     PrimeCurve,
 };
@@ -121,6 +122,7 @@ impl Plaintext {
 
         let cipher: super::key::AesCcm = key.into();
         let nonce = Nonce::generate();
+
         let wire = serialize(&self).unwrap();
         let ciphertext = cipher.encrypt(&nonce.to_nonce(), wire.as_slice()).unwrap();
 
@@ -156,12 +158,12 @@ impl Plaintext {
         key: SecretKey<C>,
     ) -> Result<Self, Error>
     where
-        C: PrimeCurve + CurveAlgorithm,
+        C: PrimeCurve + CurveAlgorithm + CurveArithmetic,
         FieldBytesSize<C>: ModulusSize + Unsigned,
     {
         let asym_algorithm = C::asymmetric_algorithm();
 
-        let object_info = wrap::Info {
+        let mut object_info = wrap::Info {
             capabilities,
             object_id,
             length: 0,
@@ -173,7 +175,14 @@ impl Plaintext {
             label,
         };
 
-        let data = key.to_bytes().as_slice().to_vec();
+        let public_key = key.public_key();
+        let public_key = public_key.as_affine();
+
+        let mut data = key.to_bytes().as_slice().to_vec();
+        data.extend_from_slice(public_key.x().as_slice());
+        data.extend_from_slice(public_key.y().as_slice());
+
+        object_info.length = data.len() as u16;
 
         Ok(Self {
             algorithm,
@@ -287,5 +296,28 @@ impl<'a> SliceReader<'a> {
             self.0 = new;
             Some(out)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[test]
+    fn test_ecdsa() {
+        let secret_key = p384::SecretKey::from_bytes((&hex!("e7f8ffafd8f2e9d95c620d446b80b4a0b8a964c98d0cf6b22f2d5b88ed39d49989fba7f371eb3d132d2222cd11bfb00d")).into()).unwrap();
+
+        let plaintext = Plaintext::from_ecdsa(
+            Algorithm::Aes256Ccm,
+            0xcf,
+            Capability::SIGN_ECDSA | Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED,
+            Domain::DOM1,
+            "Signatory test key".into(),
+            secret_key,
+        )
+        .expect("build message with ecdsa key");
+
+        assert_eq!(plaintext.data, hex!("e7f8ffafd8f2e9d95c620d446b80b4a0b8a964c98d0cf6b22f2d5b88ed39d49989fba7f371eb3d132d2222cd11bfb00d63eb6adb68f45696099e5079db0f3bd0c806397b13471ac9279cca9a597e883957d258ff2baacfc7bdd7f8766299a4271849a4dd7bcb61a576fbf4f527c16bc424dcbdde2b155f6da6bc561e83a2b4058efea986556dd2b3eedfc1c763704db0"));
     }
 }

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -10,6 +10,7 @@ use ::ecdsa::{
     signature::{Keypair, Verifier},
     EcdsaCurve,
 };
+use hex_literal::hex;
 use spki::SubjectPublicKeyInfoOwned;
 use std::{str::FromStr, time::Duration};
 use x509_cert::{
@@ -19,9 +20,9 @@ use x509_cert::{
     time::Validity,
 };
 use yubihsm::{
-    asymmetric::signature::Signer as _,
+    asymmetric::{self, signature::Signer as _},
     ecdsa::{self, algorithm::CurveAlgorithm, NistP256, NistP384},
-    object, Client,
+    object, wrap, Capability, Client,
 };
 
 #[cfg(feature = "secp256k1")]
@@ -29,6 +30,8 @@ use {
     ::ecdsa::signature::{digest::Digest, DigestSigner, DigestVerifier},
     yubihsm::ecdsa::Secp256k1,
 };
+
+use crate::{clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
 
 /// Domain IDs for test key
 const TEST_SIGNING_KEY_DOMAINS: yubihsm::Domain = yubihsm::Domain::DOM1;
@@ -167,4 +170,143 @@ fn ecdsa_nistp384_ca() {
     builder
         .build::<_, der::Signature<NistP384>>(&signer)
         .unwrap();
+}
+
+#[test]
+fn ecdsa_nistp384_import_wrapped() {
+    let secret_key = p384::SecretKey::generate();
+    let public_key = secret_key.public_key();
+
+    let algorithm = wrap::Algorithm::Aes256Ccm;
+    let capabilities =
+        Capability::SIGN_ECDSA | Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED;
+    let delegated_capabilities = Capability::all();
+    let asymmetric_key_id = 206;
+
+    let plaintext = wrap::Plaintext::from_ecdsa(
+        algorithm,
+        asymmetric_key_id,
+        capabilities,
+        TEST_DOMAINS,
+        TEST_SIGNING_KEY_LABEL.into(),
+        //delegated_capabilities,
+        secret_key,
+    )
+    .expect("build message with ecdsa key");
+
+    let wrap_key = wrap::Key::from_bytes(
+        TEST_KEY_ID,
+        &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+    )
+    .unwrap();
+    let message = plaintext
+        .encrypt(&wrap_key)
+        .expect("failed to encrypt the wrapped key");
+
+    let client = crate::get_hsm_client();
+    clear_test_key_slot(&client, object::Type::WrapKey);
+    let _ = client.delete_object(asymmetric_key_id, object::Type::AsymmetricKey);
+
+    let _key_id = client
+        .put_wrap_key(
+            TEST_KEY_ID,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            capabilities,
+            delegated_capabilities,
+            algorithm,
+            &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+        )
+        .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
+
+    let handle = client
+        .import_wrapped(TEST_KEY_ID, message)
+        .expect("import asymmetric key");
+
+    assert_eq!(handle.object_id, asymmetric_key_id);
+    let public = client
+        .get_public_key(handle.object_id)
+        .expect("read public key");
+    let public = public
+        .ecdsa::<p384::NistP384>()
+        .expect("ecdsa public key expected");
+
+    assert_eq!(
+        p384::PublicKey::try_from(&public).expect("valid point"),
+        public_key
+    );
+}
+
+#[test]
+fn ecdsa_nistp384_put_key() {
+    let secret_key = p384::SecretKey::from_slice(&[
+        0xe7, 0xf8, 0xff, 0xaf, 0xd8, 0xf2, 0xe9, 0xd9, 0x5c, 0x62, 0xd, 0x44, 0x6b, 0x80, 0xb4,
+        0xa0, 0xb8, 0xa9, 0x64, 0xc9, 0x8d, 0xc, 0xf6, 0xb2, 0x2f, 0x2d, 0x5b, 0x88, 0xed, 0x39,
+        0xd4, 0x99, 0x89, 0xfb, 0xa7, 0xf3, 0x71, 0xeb, 0x3d, 0x13, 0x2d, 0x22, 0x22, 0xcd, 0x11,
+        0xbf, 0xb0, 0xd,
+    ])
+    .expect("parse static key");
+    let public_key = secret_key.public_key();
+
+    let capabilities = Capability::SIGN_ECDSA
+        | Capability::EXPORT_WRAPPED
+        | Capability::IMPORT_WRAPPED
+        | Capability::EXPORTABLE_UNDER_WRAP;
+    let delegated_capabilities = Capability::all();
+    let asymmetric_key_id = 207;
+    let algorithm = wrap::Algorithm::Aes256Ccm;
+
+    let client = crate::get_hsm_client();
+    let _ = client.delete_object(asymmetric_key_id, object::Type::AsymmetricKey);
+
+    let _key_id = client
+        .put_asymmetric_key(
+            asymmetric_key_id,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            capabilities,
+            asymmetric::Algorithm::EcP384,
+            secret_key.to_bytes(),
+        )
+        .unwrap_or_else(|err| panic!("error putting asymmetric key: {err}"));
+
+    let public = client
+        .get_public_key(asymmetric_key_id)
+        .expect("read public key");
+    let public = public
+        .ecdsa::<p384::NistP384>()
+        .expect("ecdsa public key expected");
+
+    assert_eq!(
+        p384::PublicKey::try_from(&public).expect("valid point"),
+        public_key
+    );
+
+    clear_test_key_slot(&client, object::Type::WrapKey);
+    let wrap_key = wrap::Key::from_bytes(
+        TEST_KEY_ID,
+        &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+    )
+    .unwrap();
+    let _key_id = client
+        .put_wrap_key(
+            TEST_KEY_ID,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            capabilities,
+            delegated_capabilities,
+            algorithm,
+            &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+        )
+        .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
+
+    let message = client
+        .export_wrapped(TEST_KEY_ID, object::Type::AsymmetricKey, asymmetric_key_id)
+        .expect("Export key");
+
+    let plaintext = message
+        .decrypt(&wrap_key)
+        .expect("failed to decrypt the wrapped key");
+
+    assert_eq!(plaintext.object_info.length, 144);
 }


### PR DESCRIPTION
When serializing an ecdsa private key, the YubiHSM expects the plaintext to have the private key followed by the public affine points.

This fixes #549 