### PR TITLE
serialization: allow deserializers to be reused with json

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -101,6 +101,16 @@ impl<'de> Deserialize<'de> for Domain {
             {
                 Domain::from_bits(value).ok_or_else(|| E::custom("invalid domain bitflags"))
             }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Domain, E>
+            where
+                E: de::Error,
+            {
+                self.visit_u16(
+                    u16::try_from(value)
+                        .map_err(|_| E::custom("2-bytes containing domain bitflags"))?,
+                )
+            }
         }
 
         deserializer.deserialize_u16(DomainVisitor)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,6 +29,12 @@ macro_rules! impl_algorithm_serializers {
                     fn visit_u8<E: de::Error>(self, value: u8) -> Result<$alg, E> {
                         $alg::from_u8(value).or_else(|e| Err(E::custom(format!("{}", e))))
                     }
+
+                    fn visit_u64<E: de::Error>(self, value: u64) -> Result<$alg, E> {
+                        self.visit_u8(
+                            u8::try_from(value).map_err(|_| E::custom("an unsigned tag byte"))?,
+                        )
+                    }
                 }
 
                 deserializer.deserialize_u8(AlgorithmVisitor)

--- a/src/object/origins.rs
+++ b/src/object/origins.rs
@@ -67,6 +67,16 @@ impl<'de> Deserialize<'de> for Origin {
             {
                 Origin::from_u8(value).map_err(E::custom)
             }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Origin, E>
+            where
+                E: de::Error,
+            {
+                self.visit_u8(
+                    u8::try_from(value)
+                        .map_err(|_| E::custom("an unsigned byte between 0x01 and 0x07"))?,
+                )
+            }
         }
 
         deserializer.deserialize_u8(OriginVisitor)


### PR DESCRIPTION
When using the object::Info externally like in a json, the json deserialization library will provide the integers as u64, even if the values fit in a u8.

This adjusts the deserializers to accept an u64 and convert that back to a u8 or u16 depending on the exact type.