### PR TITLE
Add `Client::export_wrapped_with_seed` for exporting ed25519 keys

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -289,6 +289,31 @@ impl Client {
                 wrap_key_id,
                 object_type,
                 object_id,
+                include_seed: false.into(),
+            })?
+            .0)
+    }
+
+    /// Export an encrypted object from the HSM using the given key-wrapping key including the private key seed.
+    ///
+    /// For YubiHSM devices with firmware version 2.4 or later, this command enables exporting ed25519 keys with
+    /// the seed for a private key. To ensure backward compatibility with older versions of the HSM, the default
+    /// is to not export the seed. Importing such a legacy format results in an all-zero seed if such a key is
+    /// exported in the future.
+    ///
+    /// <https://developers.yubico.com/YubiHSM2/Commands/Export_Wrapped.html>
+    pub fn export_wrapped_with_seed(
+        &self,
+        wrap_key_id: object::Id,
+        object_type: object::Type,
+        object_id: object::Id,
+    ) -> Result<wrap::Message, Error> {
+        Ok(self
+            .send_command(ExportWrappedCommand {
+                wrap_key_id,
+                object_type,
+                object_id,
+                include_seed: true.into(),
             })?
             .0)
     }

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -266,6 +266,7 @@ fn export_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
         wrap_key_id,
         object_type,
         object_id,
+        include_seed: _,
     } = deserialize(cmd_data)
         .unwrap_or_else(|e| panic!("error parsing Code::ExportWrapped: {e:?}"));
 

--- a/src/wrap/commands/export.rs
+++ b/src/wrap/commands/export.rs
@@ -21,6 +21,9 @@ pub(crate) struct ExportWrappedCommand {
 
     /// Object ID of the object to be exported (in encrypted form)
     pub object_id: object::Id,
+
+    /// Export ED25519 key with its seed. Default is not to.
+    pub include_seed: u8,
 }
 
 impl Command for ExportWrappedCommand {

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -129,7 +129,7 @@ fn wrap_deserialize() {
         .unwrap_or_else(|err| panic!("error generating asymmetric key: {err}"));
 
     let wrap_data = client
-        .export_wrapped(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
+        .export_wrapped_with_seed(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
         .unwrap_or_else(|err| panic!("error exporting key: {err}"));
 
     let wrap_key = wrap::Key::from_bytes(TEST_KEY_ID, AESCCM_TEST_VECTORS[0].key).unwrap();


### PR DESCRIPTION
The default export includes only the extended private key (scalar and the hash prefix). Starting with firmware version 2.4 it is possible to include the private key seed in the backup.

This PR adds a function that will enable export of the private key seed for ed25519 keys. It has no effect on other types of keys.

Including support for that in MockHSM would be blocked by https://github.com/iqlusioninc/yubihsm.rs/pull/654. I've tested it on a real YubiHSM2 token I have here.