### PR TITLE
Add change_authentication_key client method (0x6c)

### DIFF
--- a/src/authentication/commands.rs
+++ b/src/authentication/commands.rs
@@ -1,6 +1,7 @@
-//! Put an existing auth key into the `YubiHSM 2`
+//! Authentication key commands for the `YubiHSM 2`
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/Put_Authentication_Key.html>
+//! <https://developers.yubico.com/YubiHSM2/Commands/Change_Authentication_Key.html>
 
 use crate::{
     authentication,
@@ -8,6 +9,7 @@ use crate::{
     command::{self, Command},
     object,
     response::Response,
+    Algorithm,
 };
 use serde::{Deserialize, Serialize};
 
@@ -37,4 +39,39 @@ pub(crate) struct PutAuthenticationKeyResponse {
 
 impl Response for PutAuthenticationKeyResponse {
     const COMMAND_CODE: command::Code = command::Code::PutAuthenticationKey;
+}
+
+/// Request parameters for `command::change_authentication_key`
+///
+/// Available with firmware version 2.2.0 or later.
+/// Atomically replaces the key material of the Authentication Key used to
+/// establish the current session, preserving all metadata (domains,
+/// capabilities, delegated capabilities).
+///
+/// Protocol: `Tc = 0x6c  Vc = I || A || Ke || Km`
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct ChangeAuthenticationKeyCommand {
+    /// Object ID of the authentication key to change (must be the session key)
+    pub key_id: object::Id,
+
+    /// Algorithm identifier (1 byte)
+    pub algorithm: Algorithm,
+
+    /// New authentication key (Ke || Km, 32 bytes)
+    pub authentication_key: authentication::Key,
+}
+
+impl Command for ChangeAuthenticationKeyCommand {
+    type ResponseType = ChangeAuthenticationKeyResponse;
+}
+
+/// Response from `command::change_authentication_key`
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct ChangeAuthenticationKeyResponse {
+    /// ID of the changed key
+    pub key_id: object::Id,
+}
+
+impl Response for ChangeAuthenticationKeyResponse {
+    const COMMAND_CODE: command::Code = command::Code::ChangeAuthenticationKey;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -647,12 +647,18 @@ impl Client {
     /// domains, capabilities, delegated capabilities).
     ///
     /// Only the Authentication Key that was used to open the current session
-    /// can be changed with this command. The required capability is
+    /// can be changed with this command; passing any other `key_id` will be
+    /// rejected by the device. The required capability is
     /// `change-authentication-key`.
+    ///
+    /// If this client was opened with reconnection enabled, its cached
+    /// credentials are updated to the new key material, so that reconnecting
+    /// after a session timeout continues to work. This is why the method takes
+    /// `&mut self`.
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Change_Authentication_Key.html>
     pub fn change_authentication_key<K>(
-        &self,
+        &mut self,
         key_id: object::Id,
         algorithm: authentication::Algorithm,
         authentication_key: K,
@@ -660,13 +666,25 @@ impl Client {
     where
         K: Into<authentication::Key>,
     {
-        Ok(self
+        let authentication_key = authentication_key.into();
+
+        let changed_id = self
             .send_command(ChangeAuthenticationKeyCommand {
                 key_id,
                 algorithm: algorithm.into(),
-                authentication_key: authentication_key.into(),
+                authentication_key: authentication_key.clone(),
             })?
-            .key_id)
+            .key_id;
+
+        // Keep cached credentials in sync, otherwise a later reconnect would
+        // authenticate with key material the device no longer accepts.
+        if let Some(credentials) = self.credentials.as_mut() {
+            if credentials.authentication_key_id == changed_id {
+                credentials.authentication_key = authentication_key;
+            }
+        }
+
+        Ok(changed_id)
     }
 
     /// Put an existing HMAC key into the HSM.

--- a/src/client.rs
+++ b/src/client.rs
@@ -638,6 +638,35 @@ impl Client {
             .key_id)
     }
 
+    /// Change the authentication key used to establish the current session.
+    ///
+    /// Available with firmware version 2.2.0 or later. Atomically replaces
+    /// the key material while preserving all object metadata (ID, label,
+    /// domains, capabilities, delegated capabilities).
+    ///
+    /// Only the Authentication Key that was used to open the current session
+    /// can be changed with this command. The required capability is
+    /// `change-authentication-key`.
+    ///
+    /// <https://developers.yubico.com/YubiHSM2/Commands/Change_Authentication_Key.html>
+    pub fn change_authentication_key<K>(
+        &self,
+        key_id: object::Id,
+        algorithm: authentication::Algorithm,
+        authentication_key: K,
+    ) -> Result<object::Id, Error>
+    where
+        K: Into<authentication::Key>,
+    {
+        Ok(self
+            .send_command(ChangeAuthenticationKeyCommand {
+                key_id,
+                algorithm: algorithm.into(),
+                authentication_key: authentication_key.into(),
+            })?
+            .key_id)
+    }
+
     /// Put an existing HMAC key into the HSM.
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Put_Hmac_Key.html>

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -128,6 +128,7 @@ pub(crate) fn session_message(
         Code::ImportWrapped => import_wrapped(state, &command.data),
         Code::ListObjects => list_objects(state, &command.data),
         Code::PutAsymmetricKey => put_asymmetric_key(state, &command.data),
+        Code::ChangeAuthenticationKey => change_authentication_key(state, &command.data),
         Code::PutAuthenticationKey => put_authentication_key(state, &command.data),
         Code::PutHmacKey => put_hmac_key(state, &command.data),
         Code::PutOpaqueObject => put_opaque(state, &command.data),
@@ -527,6 +528,37 @@ fn put_asymmetric_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     );
 
     PutAsymmetricKeyResponse { key_id: params.id }.serialize()
+}
+
+/// Change an existing authentication key in the HSM (atomic key material replacement)
+fn change_authentication_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
+    let ChangeAuthenticationKeyCommand {
+        key_id,
+        algorithm: _,
+        authentication_key,
+    } = deserialize(cmd_data)
+        .unwrap_or_else(|e| panic!("error parsing Code::ChangeAuthenticationKey: {e:?}"));
+
+    // In the mock, just overwrite the key data in-place
+    let obj = state
+        .objects
+        .get(key_id, object::Type::AuthenticationKey)
+        .unwrap_or_else(|| panic!("auth key {key_id} not found for ChangeAuthenticationKey"));
+
+    // Re-put with the same metadata but new key material
+    let info = obj.object_info.clone();
+    state.objects.put(
+        key_id,
+        object::Type::AuthenticationKey,
+        info.algorithm,
+        info.label,
+        info.capabilities,
+        info.delegated_capabilities,
+        info.domains,
+        &authentication_key.0,
+    );
+
+    ChangeAuthenticationKeyResponse { key_id }.serialize()
 }
 
 /// Put a new authentication key into the HSM

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -128,7 +128,9 @@ pub(crate) fn session_message(
         Code::ImportWrapped => import_wrapped(state, &command.data),
         Code::ListObjects => list_objects(state, &command.data),
         Code::PutAsymmetricKey => put_asymmetric_key(state, &command.data),
-        Code::ChangeAuthenticationKey => change_authentication_key(state, &command.data),
+        Code::ChangeAuthenticationKey => {
+            change_authentication_key(state, session_id, &command.data)
+        }
         Code::PutAuthenticationKey => put_authentication_key(state, &command.data),
         Code::PutHmacKey => put_hmac_key(state, &command.data),
         Code::PutOpaqueObject => put_opaque(state, &command.data),
@@ -530,8 +532,15 @@ fn put_asymmetric_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
     PutAsymmetricKeyResponse { key_id: params.id }.serialize()
 }
 
-/// Change an existing authentication key in the HSM (atomic key material replacement)
-fn change_authentication_key(state: &mut State, cmd_data: &[u8]) -> response::Message {
+/// Change an existing authentication key's key material.
+///
+/// The device only permits changing the authentication key that established
+/// the current session, and preserves all of the object's metadata.
+fn change_authentication_key(
+    state: &mut State,
+    session_id: session::Id,
+    cmd_data: &[u8],
+) -> response::Message {
     let ChangeAuthenticationKeyCommand {
         key_id,
         algorithm: _,
@@ -539,14 +548,32 @@ fn change_authentication_key(state: &mut State, cmd_data: &[u8]) -> response::Me
     } = deserialize(cmd_data)
         .unwrap_or_else(|e| panic!("error parsing Code::ChangeAuthenticationKey: {e:?}"));
 
-    // In the mock, just overwrite the key data in-place
-    let obj = state
-        .objects
-        .get(key_id, object::Type::AuthenticationKey)
-        .unwrap_or_else(|| panic!("auth key {key_id} not found for ChangeAuthenticationKey"));
+    // Only the authentication key backing the current session may be changed.
+    let session_key_id = match state.get_session(session_id) {
+        Ok(session) => session.authentication_key_id,
+        Err(_) => return device::ErrorKind::InvalidSession.into(),
+    };
 
-    // Re-put with the same metadata but new key material
-    let info = obj.object_info.clone();
+    if key_id != session_key_id {
+        debug!(
+            "ChangeAuthenticationKey: key {key_id} does not back the current session ({session_key_id})"
+        );
+        return device::ErrorKind::InvalidCommand.into();
+    }
+
+    // Preserve the existing metadata; only the key material changes.
+    let info = match state.objects.get(key_id, object::Type::AuthenticationKey) {
+        Some(obj) => obj.object_info.clone(),
+        None => {
+            debug!("no such authentication key: {key_id}");
+            return device::ErrorKind::ObjectNotFound.into();
+        }
+    };
+
+    // `Objects::put` asserts the slot is empty, so vacate it first.
+    state
+        .objects
+        .remove(key_id, object::Type::AuthenticationKey);
     state.objects.put(
         key_id,
         object::Type::AuthenticationKey,

--- a/src/mockhsm/session.rs
+++ b/src/mockhsm/session.rs
@@ -3,7 +3,7 @@
 use std::fmt::{self, Debug};
 
 use crate::{
-    command, response,
+    command, object, response,
     session::{
         securechannel::{Challenge, Cryptogram, SecureChannel},
         Id,
@@ -24,6 +24,12 @@ pub(crate) struct HsmSession {
 
     /// Authentication key's capabilities
     pub auth_capabilities: Capability,
+
+    /// ID of the authentication key this session was established with.
+    ///
+    /// `ChangeAuthenticationKey` may only target this key, matching the
+    /// device's behavior.
+    pub authentication_key_id: object::Id,
 }
 
 impl HsmSession {
@@ -33,12 +39,14 @@ impl HsmSession {
         card_challenge: Challenge,
         channel: SecureChannel,
         auth_capabilities: Capability,
+        authentication_key_id: object::Id,
     ) -> Self {
         Self {
             id,
             card_challenge,
             channel,
             auth_capabilities,
+            authentication_key_id,
         }
     }
 

--- a/src/mockhsm/state.rs
+++ b/src/mockhsm/state.rs
@@ -82,7 +82,13 @@ impl State {
             )
         };
 
-        let session = HsmSession::new(session_id, card_challenge, channel, capabilities);
+        let session = HsmSession::new(
+            session_id,
+            card_challenge,
+            channel,
+            capabilities,
+            authentication_key_id,
+        );
         assert!(self.sessions.insert(session_id, session).is_none());
 
         self.get_session(session_id).unwrap()

--- a/tests/command/change_authentication_key.rs
+++ b/tests/command/change_authentication_key.rs
@@ -1,52 +1,144 @@
 use yubihsm::{authentication, object, Capability};
 
-use crate::{clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL, TEST_MESSAGE};
+use crate::{TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
 
-/// Change an authentication key's key material in the `YubiHSM`
-#[test]
-fn change_authentication_key() {
-    let client = crate::get_hsm_client();
-    let algorithm = authentication::Algorithm::YubicoAes;
-    let capabilities = Capability::all();
-    let delegated_capabilities = Capability::all();
+const OLD_PASSWORD: &[u8] = b"original password";
+const NEW_PASSWORD: &[u8] = b"replacement password";
 
-    clear_test_key_slot(&client, object::Type::AuthenticationKey);
+/// Provision an authentication key at `TEST_KEY_ID` on a fresh HSM, using the
+/// default admin credentials, and return a connector for it.
+///
+/// Each test gets its own HSM instance: rotating an authentication key
+/// invalidates credentials, which would otherwise break the shared test client
+/// part-way through the suite.
+fn provision() -> yubihsm::Connector {
+    let connector = crate::create_hsm_connector();
 
-    // First, put a key so we have something to change
-    let original_key = authentication::Key::derive_from_password(TEST_MESSAGE);
+    let admin = yubihsm::Client::open(connector.clone(), Default::default(), true)
+        .unwrap_or_else(|err| panic!("error opening admin session: {err}"));
 
-    let key_id = client
+    admin
         .put_authentication_key(
             TEST_KEY_ID,
             TEST_KEY_LABEL.into(),
             TEST_DOMAINS,
-            capabilities,
-            delegated_capabilities,
-            algorithm,
-            original_key,
+            Capability::all(),
+            Capability::all(),
+            authentication::Algorithm::YubicoAes,
+            authentication::Key::derive_from_password(OLD_PASSWORD),
         )
         .unwrap_or_else(|err| panic!("error putting auth key: {err}"));
 
-    assert_eq!(key_id, TEST_KEY_ID);
+    connector
+}
 
-    // Now change the key material — metadata should be preserved
-    let new_key = authentication::Key::derive_from_password(b"new password");
+/// Changing the key that established the current session replaces its key
+/// material and preserves all of its metadata.
+#[test]
+fn change_authentication_key() {
+    let connector = provision();
+    let algorithm = authentication::Algorithm::YubicoAes;
+
+    let mut client = yubihsm::Client::open(
+        connector.clone(),
+        yubihsm::Credentials::from_password(TEST_KEY_ID, OLD_PASSWORD),
+        true,
+    )
+    .unwrap_or_else(|err| panic!("error opening session with original key: {err}"));
 
     let changed_id = client
-        .change_authentication_key(TEST_KEY_ID, algorithm, new_key)
+        .change_authentication_key(
+            TEST_KEY_ID,
+            algorithm,
+            authentication::Key::derive_from_password(NEW_PASSWORD),
+        )
         .unwrap_or_else(|err| panic!("error changing auth key: {err}"));
 
     assert_eq!(changed_id, TEST_KEY_ID);
 
-    // Verify metadata is preserved after change
+    // Metadata must survive the rotation.
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AuthenticationKey)
         .unwrap_or_else(|err| panic!("error getting object info: {err}"));
 
-    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.capabilities, Capability::all());
     assert_eq!(object_info.object_id, TEST_KEY_ID);
     assert_eq!(object_info.domains, TEST_DOMAINS);
     assert_eq!(object_info.object_type, object::Type::AuthenticationKey);
     assert_eq!(object_info.algorithm, algorithm.into());
     assert_eq!(&object_info.label.to_string(), TEST_KEY_LABEL);
+}
+
+/// The key material really changes: the new key authenticates and the old one
+/// stops working.
+///
+/// Without this, a `change_authentication_key` that silently did nothing would
+/// still pass the metadata assertions above.
+#[test]
+fn change_authentication_key_replaces_key_material() {
+    let connector = provision();
+
+    let mut client = yubihsm::Client::open(
+        connector.clone(),
+        yubihsm::Credentials::from_password(TEST_KEY_ID, OLD_PASSWORD),
+        true,
+    )
+    .unwrap_or_else(|err| panic!("error opening session with original key: {err}"));
+
+    client
+        .change_authentication_key(
+            TEST_KEY_ID,
+            authentication::Algorithm::YubicoAes,
+            authentication::Key::derive_from_password(NEW_PASSWORD),
+        )
+        .unwrap_or_else(|err| panic!("error changing auth key: {err}"));
+
+    // The new key must authenticate.
+    yubihsm::Client::open(
+        connector.clone(),
+        yubihsm::Credentials::from_password(TEST_KEY_ID, NEW_PASSWORD),
+        true,
+    )
+    .unwrap_or_else(|err| panic!("new key should authenticate, got: {err}"));
+
+    // The old key must not.
+    assert!(
+        yubihsm::Client::open(
+            connector.clone(),
+            yubihsm::Credentials::from_password(TEST_KEY_ID, OLD_PASSWORD),
+            true,
+        )
+        .is_err(),
+        "old key must no longer authenticate after being changed"
+    );
+}
+
+/// The device only allows changing the authentication key that established the
+/// current session. Attempting to change any other key is rejected.
+#[test]
+fn change_authentication_key_rejects_other_keys() {
+    let connector = provision();
+
+    // Authenticated as the default admin key, not as `TEST_KEY_ID`.
+    let mut admin = yubihsm::Client::open(connector.clone(), Default::default(), true)
+        .unwrap_or_else(|err| panic!("error opening admin session: {err}"));
+
+    assert!(
+        admin
+            .change_authentication_key(
+                TEST_KEY_ID,
+                authentication::Algorithm::YubicoAes,
+                authentication::Key::derive_from_password(NEW_PASSWORD),
+            )
+            .is_err(),
+        "changing an authentication key other than the session's must be rejected"
+    );
+
+    // The untouched key must still authenticate with its original password.
+    yubihsm::Client::open(
+        connector.clone(),
+        yubihsm::Credentials::from_password(TEST_KEY_ID, OLD_PASSWORD),
+        true,
+    )
+    .unwrap_or_else(|err| panic!("untouched key should still authenticate, got: {err}"));
 }

--- a/tests/command/change_authentication_key.rs
+++ b/tests/command/change_authentication_key.rs
@@ -1,0 +1,52 @@
+use yubihsm::{authentication, object, Capability};
+
+use crate::{clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL, TEST_MESSAGE};
+
+/// Change an authentication key's key material in the `YubiHSM`
+#[test]
+fn change_authentication_key() {
+    let client = crate::get_hsm_client();
+    let algorithm = authentication::Algorithm::YubicoAes;
+    let capabilities = Capability::all();
+    let delegated_capabilities = Capability::all();
+
+    clear_test_key_slot(&client, object::Type::AuthenticationKey);
+
+    // First, put a key so we have something to change
+    let original_key = authentication::Key::derive_from_password(TEST_MESSAGE);
+
+    let key_id = client
+        .put_authentication_key(
+            TEST_KEY_ID,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            capabilities,
+            delegated_capabilities,
+            algorithm,
+            original_key,
+        )
+        .unwrap_or_else(|err| panic!("error putting auth key: {err}"));
+
+    assert_eq!(key_id, TEST_KEY_ID);
+
+    // Now change the key material — metadata should be preserved
+    let new_key = authentication::Key::derive_from_password(b"new password");
+
+    let changed_id = client
+        .change_authentication_key(TEST_KEY_ID, algorithm, new_key)
+        .unwrap_or_else(|err| panic!("error changing auth key: {err}"));
+
+    assert_eq!(changed_id, TEST_KEY_ID);
+
+    // Verify metadata is preserved after change
+    let object_info = client
+        .get_object_info(TEST_KEY_ID, object::Type::AuthenticationKey)
+        .unwrap_or_else(|err| panic!("error getting object info: {err}"));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, object::Type::AuthenticationKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(&object_info.label.to_string(), TEST_KEY_LABEL);
+}

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -1,6 +1,7 @@
 //! Integration tests for YubiHSM 2 commands
 
 pub mod blink_device;
+pub mod change_authentication_key;
 pub mod decrypt_oaep;
 pub mod delete_object;
 pub mod device_info;


### PR DESCRIPTION
# Add `Client::change_authentication_key` (0x6c)

Implements the `CHANGE AUTHENTICATION KEY` command (0x6c), available since firmware 2.2.0.

This command atomically replaces the key material of the Authentication Key used to open the current session, preserving all object metadata (ID, label, domains, capabilities, delegated capabilities).

## Motivation

The crate already defines the command code (`Code::ChangeAuthenticationKey = 0x6c`) but does not expose a client method for it. Without this, the only way to rotate an authentication key is the `delete_object` + `put_authentication_key` pattern, which has several problems:

- **Not atomic** — there is a window where the auth key object does not exist. If the session drops or the audit log fills (force-audit mode) between the delete and the put, the device is bricked.
- **Capability issues** — after deleting the session's own auth key, the HSM may fail the subsequent `put_authentication_key` with "insufficient permissions" because it can no longer look up the delegated capabilities of the (now-deleted) session key.
- **Requires broader capabilities** — `put-authentication-key` vs the narrower `change-authentication-key`.
