### PR TITLE
Derive `PartialOrd` and `Ord` for `Algorithm`, `Capability` and `Domain`

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -7,7 +7,7 @@ pub use self::error::{Error, ErrorKind};
 use crate::{asymmetric, authentication, ecdh, ecdsa, hmac, opaque, otp, rsa, template, wrap};
 
 /// Cryptographic algorithm types supported by the `YubiHSM 2`
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Asymmetric algorithms

--- a/src/asymmetric/algorithm.rs
+++ b/src/asymmetric/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Asymmetric algorithms (RSA or ECC)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// 2048-bit RSA

--- a/src/authentication/algorithm.rs
+++ b/src/authentication/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for auth keys
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// YubiHSM AES PSK authentication

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -14,7 +14,7 @@ bitflags! {
     /// Object attributes specifying which operations are allowed to be performed
     ///
     /// <https://developers.yubico.com/YubiHSM2/Concepts/Capability.html>
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
     pub struct Capability: u64 {
         /// `derive-ecdh`: perform ECDH operation
         const DERIVE_ECDH = 0x800;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -36,7 +36,7 @@ bitflags! {
     /// basis. For more information, see the Yubico documentation:
     ///
     /// <https://developers.yubico.com/YubiHSM2/Concepts/Domain.html>
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
     pub struct Domain: u16 {
         const DOM1 = 0x0001;
         const DOM2 = 0x0002;

--- a/src/ecdh/algorithm.rs
+++ b/src/ecdh/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Key exchange algorithms (a.k.a. Diffie-Hellman)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Elliptic Curve Diffie-Hellman (Weierstrass)

--- a/src/ecdsa/algorithm.rs
+++ b/src/ecdsa/algorithm.rs
@@ -7,7 +7,7 @@ use crate::{algorithm, asymmetric};
 use super::Secp256k1;
 
 /// Valid algorithms for asymmetric keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `ecdsa-sha1`

--- a/src/hmac/algorithm.rs
+++ b/src/hmac/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for HMAC keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `hmac-sha1`

--- a/src/opaque/algorithm.rs
+++ b/src/opaque/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for opaque data
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Arbitrary opaque data

--- a/src/otp/algorithm.rs
+++ b/src/otp/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for Yubico OTP (AES-based one time password) keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Yubico OTP using AES-128

--- a/src/rsa/algorithm.rs
+++ b/src/rsa/algorithm.rs
@@ -5,7 +5,7 @@ use crate::algorithm;
 use digest::{const_oid::AssociatedOid, Digest};
 
 /// RSA algorithms (signing and encryption)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// RSA encryption with Optimal Asymmetric Encryption Padding (OAEP)

--- a/src/rsa/mgf.rs
+++ b/src/rsa/mgf.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Mask generating functions for RSASSA-PSS
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `mgf-sha1`

--- a/src/rsa/oaep/algorithm.rs
+++ b/src/rsa/oaep/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// RSA Optimal Asymmetric Encryption Padding (OAEP) algorithms
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `rsa-oaep-sha1`

--- a/src/rsa/pkcs1/algorithm.rs
+++ b/src/rsa/pkcs1/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// RSA PKCS#1v1.5: legacy algorithms
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `rsa-pkcs1-sha1`

--- a/src/rsa/pss/algorithm.rs
+++ b/src/rsa/pss/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// RSASSA-PSS algorithms
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `rsa-pss-sha1`

--- a/src/template/algorithm.rs
+++ b/src/template/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Template algorithms (for SSH)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `template-ssh`

--- a/src/wrap/algorithm.rs
+++ b/src/wrap/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for "wrap" (symmetric encryption/key wrapping) keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// AES-128 in Counter with CBC-MAC (CCM) mode

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -5,7 +5,7 @@ use ::ecdsa::{
     elliptic_curve::{
         point::PointCompression,
         sec1::{self, FromSec1Point, ToSec1Point},
-        AffinePoint, CurveArithmetic, FieldBytesSize,
+        AffinePoint, CurveArithmetic, FieldBytesSize, Generate,
     },
     signature::{Keypair, Verifier},
     EcdsaCurve,

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -215,7 +215,7 @@ fn ecdsa_nistp384_import_wrapped() {
             capabilities,
             delegated_capabilities,
             algorithm,
-            &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         )
         .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 
@@ -296,7 +296,7 @@ fn ecdsa_nistp384_put_key() {
             capabilities,
             delegated_capabilities,
             algorithm,
-            &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         )
         .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -77,6 +77,7 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
         .unwrap();
 }
 
+#[cfg(feature = "untested")]
 #[test]
 fn ecdsa_nistp256_sign_test() {
     let signer = create_signer::<NistP256>(201);


### PR DESCRIPTION
Also fixes minor issues, observed while running tests (clippy warnings, missing traits and test guards).