### PR TITLE
Make use of `Label` safer and derive `Clone`, `Debug`, `Deserialize` and `Serialize` for `Filter`

### DIFF
--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -131,7 +131,9 @@ impl Default for Objects {
             length: authentication::key::SIZE as u16,
             sequence: 1,
             origin: Origin::Imported,
-            label: DEFAULT_AUTHENTICATION_KEY_LABEL.into(),
+            label: DEFAULT_AUTHENTICATION_KEY_LABEL.parse().expect(
+                "the default authentication key label to be less than or equal to 40 bytes",
+            ),
         };
 
         let authentication_key_payload = Payload::AuthenticationKey(authentication::Key::default());
@@ -158,7 +160,9 @@ impl Default for Objects {
             length: 0,
             sequence: 0,
             origin: Origin::Generated,
-            label: "MOCKHSM ATTESTATION KEY".into(),
+            label: "MOCKHSM ATTESTATION KEY".parse().expect(
+                "the default mockhsm attestation key label to be less than or equal to 40 bytes",
+            ),
         };
         let attestation_cert_info = Info {
             object_id: DEFAULT_ATTESTATION_KEY_ID,
@@ -170,7 +174,9 @@ impl Default for Objects {
             length: 0,
             sequence: 0,
             origin: Origin::Generated,
-            label: "MOCKHSM ATTESTATION CERT".into(),
+            label: "MOCKHSM ATTESTATION CERT".parse().expect(
+                "the default mockhsm attestation cert label to be less than or equal to 40 bytes",
+            ),
         };
 
         let attestation_cert_payload = Payload::Opaque(

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -1,5 +1,7 @@
 //! Filters for selecting objects in the list object command
 
+use serde::{Deserialize, Serialize};
+
 use crate::{algorithm::Algorithm, capability::Capability, client, domain::Domain, object};
 use std::io::Write;
 
@@ -10,7 +12,7 @@ use {
 };
 
 /// Filters to apply when listing objects
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Filter {
     /// Filter objects by algorithm
     Algorithm(Algorithm),

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -10,6 +10,7 @@ use {
 };
 
 /// Filters to apply when listing objects
+#[derive(Clone, Debug)]
 pub enum Filter {
     /// Filter objects by algorithm
     Algorithm(Algorithm),

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -84,12 +84,6 @@ impl FromStr for Label {
     }
 }
 
-impl<'a> From<&'a str> for Label {
-    fn from(s: &'a str) -> Self {
-        Self::from_str(s).unwrap()
-    }
-}
-
 impl PartialEq for Label {
     fn eq(&self, other: &Self) -> bool {
         self.0[..] == other.0[..]

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -14,6 +14,7 @@ pub const LABEL_SIZE: usize = 40;
 const INVALID_LABEL_STR_PLACEHOLDER: &str = "[INVALID UTF-8 CHARACTER IN LABEL]";
 
 /// Labels attached to objects
+#[derive(Clone)]
 pub struct Label(pub [u8; LABEL_SIZE]);
 
 impl Label {
@@ -46,12 +47,6 @@ impl Label {
 impl AsRef<[u8]> for Label {
     fn as_ref(&self) -> &[u8] {
         &self.0
-    }
-}
-
-impl Clone for Label {
-    fn clone(&self) -> Self {
-        Self::from_bytes(self.as_ref()).unwrap()
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,7 +49,9 @@ pub fn init_with_profile(client: Client, profile: Profile) -> Result<Report, Err
     client
         .put_authentication_key(
             setup_auth_key_id,
-            SETUP_KEY_LABEL.into(),
+            SETUP_KEY_LABEL
+                .parse()
+                .map_err(|_error| ErrorKind::LabelInvalid)?,
             Domain::all(),
             Capability::all(),
             Capability::all(),

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -76,7 +76,9 @@ impl Report {
         client
             .put_opaque(
                 report_object_id,
-                object::Label::from(REPORT_OBJECT_LABEL),
+                REPORT_OBJECT_LABEL
+                    .parse()
+                    .map_err(|_error| ErrorKind::LabelInvalid)?,
                 Domain::all(),
                 Capability::GET_OPAQUE,
                 opaque::Algorithm::Data,

--- a/src/wrap/message.rs
+++ b/src/wrap/message.rs
@@ -313,7 +313,9 @@ mod tests {
             0xcf,
             Capability::SIGN_ECDSA | Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED,
             Domain::DOM1,
-            "Signatory test key".into(),
+            "Signatory test key"
+                .parse()
+                .expect("label to be less than or equal to 40 bytes"),
             secret_key,
         )
         .expect("build message with ecdsa key");

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -19,7 +19,9 @@ fn wrap_key_test() {
     let key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -40,7 +42,9 @@ fn wrap_key_test() {
     client
         .generate_asymmetric_key(
             TEST_EXPORTED_KEY_ID,
-            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_EXPORTED_KEY_LABEL
+                .parse()
+                .expect("TEST_EXPORTED_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             exported_key_capabilities,
             exported_key_algorithm,
@@ -100,7 +104,9 @@ fn wrap_deserialize() {
     let key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -121,7 +127,9 @@ fn wrap_deserialize() {
     client
         .generate_asymmetric_key(
             TEST_EXPORTED_KEY_ID,
-            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_EXPORTED_KEY_LABEL
+                .parse()
+                .expect("TEST_EXPORTED_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             exported_key_capabilities,
             exported_key_algorithm,
@@ -167,7 +175,9 @@ fn wrap_deserialize_rsa() {
     let key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -188,7 +198,9 @@ fn wrap_deserialize_rsa() {
     client
         .generate_asymmetric_key(
             TEST_EXPORTED_KEY_ID,
-            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_EXPORTED_KEY_LABEL
+                .parse()
+                .expect("TEST_EXPORTED_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             exported_key_capabilities,
             exported_key_algorithm,

--- a/tests/command/generate_hmac_key.rs
+++ b/tests/command/generate_hmac_key.rs
@@ -14,7 +14,9 @@ fn hmac_key_test() {
     let key_id = client
         .generate_hmac_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             algorithm,

--- a/tests/command/generate_wrap_key.rs
+++ b/tests/command/generate_wrap_key.rs
@@ -18,7 +18,9 @@ fn wrap_key_test() {
     let key_id = client
         .generate_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,

--- a/tests/command/put_authentication_key.rs
+++ b/tests/command/put_authentication_key.rs
@@ -17,7 +17,9 @@ fn put_authentication_key() {
     let key_id = client
         .put_authentication_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,

--- a/tests/command/put_opaque.rs
+++ b/tests/command/put_opaque.rs
@@ -12,7 +12,9 @@ fn opaque_object_test() {
     let object_id = client
         .put_opaque(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             Capability::default(),
             opaque::Algorithm::Data,

--- a/tests/command/verify_hmac.rs
+++ b/tests/command/verify_hmac.rs
@@ -17,7 +17,9 @@ fn hmac_test_vectors() {
         let key_id = client
             .put_hmac_key(
                 TEST_KEY_ID,
-                TEST_KEY_LABEL.into(),
+                TEST_KEY_LABEL
+                    .parse()
+                    .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
                 TEST_DOMAINS,
                 capabilities,
                 algorithm,

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -69,7 +69,9 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
     client
         .generate_asymmetric_key(
             key_id,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             TEST_SIGNING_KEY_CAPABILITIES,
             alg,
@@ -188,7 +190,9 @@ fn ecdsa_nistp384_import_wrapped() {
         asymmetric_key_id,
         capabilities,
         TEST_DOMAINS,
-        TEST_SIGNING_KEY_LABEL.into(),
+        TEST_SIGNING_KEY_LABEL
+            .parse()
+            .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
         //delegated_capabilities,
         secret_key,
     )
@@ -210,7 +214,9 @@ fn ecdsa_nistp384_import_wrapped() {
     let _key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -262,7 +268,9 @@ fn ecdsa_nistp384_put_key() {
     let _key_id = client
         .put_asymmetric_key(
             asymmetric_key_id,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             asymmetric::Algorithm::EcP384,
@@ -291,7 +299,9 @@ fn ecdsa_nistp384_put_key() {
     let _key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,

--- a/tests/ed25519/mod.rs
+++ b/tests/ed25519/mod.rs
@@ -30,7 +30,9 @@ fn create_yubihsm_key(client: &Client) {
     client
         .generate_asymmetric_key(
             TEST_SIGNING_KEY_ID,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             TEST_SIGNING_KEY_CAPABILITIES,
             yubihsm::asymmetric::Algorithm::Ed25519,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -137,7 +137,9 @@ pub fn generate_asymmetric_key(
 
     match client.generate_asymmetric_key(
         TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
+        TEST_KEY_LABEL
+            .parse()
+            .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
         TEST_DOMAINS,
         capabilities,
         algorithm,
@@ -159,7 +161,9 @@ pub fn put_asymmetric_key<T: Into<Vec<u8>>>(
     let key_id = client
         .put_asymmetric_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             algorithm,

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -44,7 +44,9 @@ fn rsa_put_asymmetric_key() {
     let id = client
         .put_asymmetric_key(
             223,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             yubihsm::Capability::SIGN_PSS,
             yubihsm::asymmetric::Algorithm::Rsa2048,
@@ -71,7 +73,9 @@ fn rsa_import_export_wrapped_key() {
         asymmetric_key_id,
         Capability::EXPORTABLE_UNDER_WRAP | Capability::SIGN_PKCS,
         TEST_DOMAINS,
-        TEST_KEY_LABEL.into(),
+        TEST_KEY_LABEL
+            .parse()
+            .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
         key.clone(),
     )
     .expect("build message with RSA key");
@@ -88,7 +92,9 @@ fn rsa_import_export_wrapped_key() {
     let _key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -163,7 +169,9 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
     let _key = client
         .generate_asymmetric_key(
             key_id,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             yubihsm::Capability::SIGN_PSS
                 | yubihsm::Capability::SIGN_PKCS

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -6,7 +6,10 @@ use yubihsm::{
 };
 
 #[cfg(feature = "setup")]
-use yubihsm::setup::{Profile, Role};
+use yubihsm::{
+    object::Label,
+    setup::{Profile, Role},
+};
 
 const ROOT_KEY_ID: object::Id = 1;
 const ROOT_KEY_LABEL: &str = "root key";
@@ -16,7 +19,11 @@ const ROOT_KEY_LABEL: &str = "root key";
 fn setup_test() {
     let root_key = authentication::Key::random();
     let root_role = Role::new(Credentials::new(ROOT_KEY_ID, root_key))
-        .authentication_key_label(ROOT_KEY_LABEL)
+        .authentication_key_label(
+            ROOT_KEY_LABEL
+                .parse::<Label>()
+                .expect("ROOT_KEY_LABEL to be equal to or shorter than 40 bytes"),
+        )
         .capabilities(Capability::all())
         .domains(Domain::all());
 


### PR DESCRIPTION
This removes the custom `Clone` impl from `Label` and replaces it with the regular derive macro.
This PR also removes the `From<&'a str>` for `Label` as that could panic.

Especially these two changes would be a good fit for a semver breaking change with version 0.43.0 (https://github.com/iqlusioninc/yubihsm.rs/issues/670).

In addition, `Clone`, `Debug`, `Deserialize` and `Serialize` are derived for `Filter`, making it more usable in downstreams that want to rely on them in their interface and require `Debug` or have serde support.

Note, that the test failure is because of an unrelated issue, fixed in #665 (https://github.com/iqlusioninc/yubihsm.rs/pull/665/changes/bd23d1a1c93df43d4ea6364badfa1e927c33f7ff).