### PR TITLE
export_wrapped: fixup include_seed serialization

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -289,7 +289,7 @@ impl Client {
                 wrap_key_id,
                 object_type,
                 object_id,
-                include_seed: false.into(),
+                include_seed: Seed::Exclude,
             })?
             .0)
     }
@@ -313,7 +313,7 @@ impl Client {
                 wrap_key_id,
                 object_type,
                 object_id,
-                include_seed: true.into(),
+                include_seed: Seed::Include,
             })?
             .0)
     }

--- a/src/wrap/commands/export.rs
+++ b/src/wrap/commands/export.rs
@@ -23,7 +23,8 @@ pub(crate) struct ExportWrappedCommand {
     pub object_id: object::Id,
 
     /// Export ED25519 key with its seed. Default is not to.
-    pub include_seed: u8,
+    #[serde(skip_serializing_if = "Seed::is_exclude", with = "seed")]
+    pub include_seed: Seed,
 }
 
 impl Command for ExportWrappedCommand {
@@ -36,4 +37,138 @@ pub(crate) struct ExportWrappedResponse(pub(crate) wrap::Message);
 
 impl Response for ExportWrappedResponse {
     const COMMAND_CODE: command::Code = command::Code::ExportWrapped;
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum Seed {
+    #[default]
+    Exclude,
+    Include,
+}
+
+impl Seed {
+    fn is_exclude(&self) -> bool {
+        matches!(self, Self::Exclude)
+    }
+}
+
+mod seed {
+    use core::fmt;
+
+    use serde::{
+        de::{self, Deserializer, Error, Unexpected, Visitor},
+        ser::Serializer,
+    };
+
+    use super::Seed;
+
+    pub(super) fn serialize<S>(value: &Seed, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Seed::Exclude => serializer.serialize_unit(),
+            Seed::Include => serializer.serialize_u8(1),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Seed, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SeedVisitor;
+
+        impl<'de> Visitor<'de> for SeedVisitor {
+            type Value = Seed;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an optional single bytes (value 1) or empty")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let value = if let Some(value) = seq.next_element::<u8>()? {
+                    if value == 1 {
+                        Seed::Include
+                    } else {
+                        return Err(A::Error::invalid_value(
+                            Unexpected::Unsigned(value.into()),
+                            &self,
+                        ));
+                    }
+                } else {
+                    return Ok(Seed::Exclude);
+                };
+
+                if seq.next_element::<u8>()?.is_some() {
+                    Err(A::Error::custom(
+                        "no value is expected after include_seed".to_string(),
+                    ))
+                } else {
+                    Ok(value)
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(SeedVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::serialization::{deserialize, serialize};
+
+    use super::*;
+
+    #[test]
+    fn seed_serialization() {
+        let mut value = ExportWrappedCommand {
+            wrap_key_id: 0,
+            object_type: object::Type::Opaque,
+            object_id: 0,
+            include_seed: Seed::Exclude,
+        };
+        assert_eq!(
+            serialize(&value).unwrap(),
+            vec![
+                0, 0, // wrap key id
+                1, // object_type
+                0, 0 // object_id
+            ]
+        );
+        value.include_seed = Seed::Include;
+        assert_eq!(
+            serialize(&value).unwrap(),
+            vec![
+                0, 0, // wrap key id
+                1, // object_type
+                0, 0, // object_id
+                1  // include_seed
+            ]
+        );
+
+        assert_eq!(
+            deserialize::<ExportWrappedCommand>(&[
+                0, 0, // wrap key id
+                1, // object_type
+                0, 0 // object_id
+            ])
+            .unwrap()
+            .include_seed,
+            Seed::Exclude
+        );
+        assert_eq!(
+            deserialize::<ExportWrappedCommand>(&[
+                0, 0, // wrap key id
+                1, // object_type
+                0, 0, // object_id
+                1, // include_seed
+            ])
+            .unwrap()
+            .include_seed,
+            Seed::Include
+        );
+    }
 }

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -48,7 +48,7 @@ fn wrap_key_test() {
         .unwrap_or_else(|err| panic!("error generating asymmetric key: {err}"));
 
     let wrap_data = client
-        .export_wrapped(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
+        .export_wrapped_with_seed(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
         .unwrap_or_else(|err| panic!("error exporting key: {err}"));
 
     let wrap_key = wrap::Key::from_bytes(TEST_KEY_ID, AESCCM_TEST_VECTORS[0].key).unwrap();
@@ -129,7 +129,7 @@ fn wrap_deserialize() {
         .unwrap_or_else(|err| panic!("error generating asymmetric key: {err}"));
 
     let wrap_data = client
-        .export_wrapped_with_seed(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
+        .export_wrapped(TEST_KEY_ID, exported_key_type, TEST_EXPORTED_KEY_ID)
         .unwrap_or_else(|err| panic!("error exporting key: {err}"));
 
     let wrap_key = wrap::Key::from_bytes(TEST_KEY_ID, AESCCM_TEST_VECTORS[0].key).unwrap();


### PR DESCRIPTION
This reworks the include seed serialization. The attribute should only be added to the message if requested. Serializing it as zero will have the device reply with `WrongLength` errors.

This is a fixup for https://github.com/iqlusioninc/yubihsm.rs/pull/661