### PR TITLE
Allow the mockhsm feature to be used in release builds too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ x509-cert = { version = "0.3.0-rc.4", features = ["builder"] }
 default = ["http", "passwords", "setup"]
 http-server = ["tiny_http"]
 http = []
+# WARNING: The `mockhsm` feature is only for testing purposes!
+# It is **neither safe nor fit** for production use!
 mockhsm = [
   "ecdsa/algorithm",
   "ed25519-dalek",

--- a/src/mockhsm.rs
+++ b/src/mockhsm.rs
@@ -1,9 +1,5 @@
 //! Simulation of the HSM for integration testing.
 
-// TESTING ONLY DO NOT PRODUCTIONIZE IT IS NOT SAFE!!!
-#[cfg(not(debug_assertions))]
-compile_error!("MockHsm is not intended for use in release builds");
-
 use std::sync::{Arc, Mutex};
 
 mod audit;


### PR DESCRIPTION
Also adds a warning to Cargo.toml explaining the use-case of the feature.
cc @wiktor-k 

Fixes https://github.com/iqlusioninc/yubihsm.rs/issues/657

Note, that failing tests are due to unrelated issues (see https://github.com/iqlusioninc/yubihsm.rs/pull/665/changes/bd23d1a1c93df43d4ea6364badfa1e927c33f7ff in https://github.com/iqlusioninc/yubihsm.rs/pull/665 for details).

It would be great if this change would make it into https://github.com/iqlusioninc/yubihsm.rs/issues/670