### PR TITLE
Use equals signs instead of newlines to separate keys from values

### DIFF
--- a/src/connector/http/server.rs
+++ b/src/connector/http/server.rs
@@ -109,7 +109,7 @@ impl Server {
 
         let body = status
             .iter()
-            .map(|(k, v)| [*k, *v].join("\n"))
+            .map(|(k, v)| [*k, *v].join("="))
             .collect::<Vec<_>>()
             .join("\n");
 


### PR DESCRIPTION
`yubihsm-connector` uses `=` as a name/value separator [source].

Adjust the values in the `status` function so that the `yubihsm-shell` can connect to it.

Without this change `yubihsm-shell` prints:

    Failed connecting 'http://localhost:12345': Unable to find a suitable connector

[source]: https://github.com/Yubico/yubihsm-connector/blob/76b26eb809a9068c497baec4b5f8761a7825c475/api.go#L157-L160