### PR TITLE
Allow invoking `DeviceInfo` command without authentication

### DIFF
--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -193,7 +193,7 @@ fn delete_object(state: &mut State, cmd_data: &[u8]) -> response::Message {
 }
 
 /// Generate a mock device information report
-fn device_info() -> response::Message {
+pub fn device_info() -> response::Message {
     let info = device::Info {
         major_version: 2,
         minor_version: 0,

--- a/src/mockhsm/connection.rs
+++ b/src/mockhsm/connection.rs
@@ -34,6 +34,7 @@ impl Connection for MockConnection {
             Code::CreateSession => command::create_session(&mut state, &command),
             Code::AuthenticateSession => command::authenticate_session(&mut state, &command),
             Code::SessionMessage => command::session_message(&mut state, command),
+            Code::DeviceInfo => Ok(command::device_info().into()),
             unsupported => fail!(ConnectionFailed, "unsupported command: {:?}", unsupported),
         }
         .map(Message::from)


### PR DESCRIPTION
Some tools, such as `yubihsm-shell` invoke that command to check if the connector contains a valid backend.