### PR TITLE
Revert "Remove session auto-close in `Drop` handler (#265)"

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -28,7 +28,10 @@ use crate::{
     device, response,
     serialization::deserialize,
 };
-use std::time::{Duration, Instant};
+use std::{
+    panic::{self, AssertUnwindSafe},
+    time::{Duration, Instant},
+};
 
 /// Timeout fuzz factor: to avoid races/skew with the YubiHSM's clock,
 /// we consider sessions to be timed out slightly earlier than the actual
@@ -121,19 +124,6 @@ impl Session {
         let idle_time = Instant::now().duration_since(self.last_active);
         let timeout_with_fuzz = self.timeout.duration() - TIMEOUT_FUZZ_FACTOR;
         idle_time >= timeout_with_fuzz
-    }
-
-    /// Close this session, consuming it in the process.
-    pub fn close(mut self) -> Result<(), Error> {
-        // Only attempt to close the session if we have an active secure
-        // channel and our session hasn't already timed out
-        if self.secure_channel.is_none() || self.is_timed_out() {
-            return Ok(());
-        }
-
-        session_debug!(self, "closing session");
-        self.send_command(&CloseSessionCommand {})?;
-        Ok(())
     }
 
     /// Abort this session, terminating it without closing it
@@ -273,5 +263,39 @@ impl Session {
         self.secure_channel
             .as_mut()
             .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed").into())
+    }
+}
+
+impl Drop for Session {
+    /// Make a best effort to close the session if it's still healthy
+    fn drop(&mut self) {
+        // Only attempt to close the session if we have an active secure
+        // channel and our session hasn't already timed out
+        if self.secure_channel.is_none() || self.is_timed_out() {
+            return;
+        }
+
+        session_debug!(self, "closing dropped session");
+
+        // TODO: ensure we're really unwind safe.
+        // This should still be better than panicking in a drop handler, hopefully
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            self.send_command(&CloseSessionCommand {}).unwrap()
+        }));
+
+        if let Err(err) = result {
+            // Attempt to extract the error message from the `Any` returned from `catch_unwind`
+            let msg = err
+                .downcast_ref::<String>()
+                .map(AsRef::as_ref)
+                .or_else(|| err.downcast_ref::<&str>().cloned())
+                .unwrap_or("unknown cause!");
+
+            error!(
+                "session={} panic closing dropped session: {}",
+                self.id.to_u8(),
+                msg
+            );
+        }
     }
 }


### PR DESCRIPTION
This reverts commit f8b80a08c8e551f459984d455453760451c7ffda.

The introduced `Session::close` method was not callable from a `Client`. Without a proper `Drop` implementation, a `Session` is not closed, which limits the use for the library, as e.g. more elaborate processes provisioning the device are not possible.

The underlying issue for TMKMS (#37) has been fixed in a different pull request (#273).

Fixes: https://github.com/iqlusioninc/yubihsm.rs/issues/495
Related-to: https://github.com/iqlusioninc/tmkms/issues/37
Related-to: https://github.com/iqlusioninc/yubihsm.rs/pull/273