### PR TITLE
chore(deps): consolidate dependencies to stable releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,15 +247,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -354,14 +355,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -541,9 +543,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce7f1aa9a24c53c6572d8017c8c1ceb5d44c6071ff68c9912860fa4d262101"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
  "ecdsa",
@@ -619,9 +621,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -632,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -646,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct 1.0.0",
  "ecdsa",
@@ -735,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478aa2e499c7164b21b4c5e8610018e5b83a284da5f9e0896907dd4749cd76c9"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "once_cell",
@@ -1244,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "wnaf"
-version = "0.14.0-rc.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfae175ab8f55e3c604de329bf66f628274c2cda893923670a73ebd1958ead2"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
  "ff",
  "group",
@@ -1255,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.3.0-rc.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e21aad3a769f25f3d2d0cbf30ea8b50a1d602354bd6ab687fad112821608ba6"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
  "const-oid",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ digest = { version = "0.11", default-features = false }
 ecdsa = { version = "0.17", default-features = false, features = ["pkcs8"] }
 ed25519 = "3"
 log = "0.4"
-p256 = { version = "0.14.0-rc.15", default-features = false, features = ["ecdsa", "sha256"] }
-p384 = { version = "0.14.0-rc.15", default-features = false, features = ["ecdsa", "sha384"] }
-p521 = { version = "0.14.0-rc.15", default-features = false, features = ["ecdsa", "sha512"] }
+p256 = { version = "0.14", default-features = false, features = ["ecdsa", "sha256"] }
+p384 = { version = "0.14", default-features = false, features = ["ecdsa", "sha384"] }
+p521 = { version = "0.14", default-features = false, features = ["ecdsa", "sha512"] }
 serde = { version = "1", features = ["serde_derive"] }
 rand = { version = "0.10" }
 rand_core = { version = "0.10" }
@@ -45,24 +45,24 @@ uuid = { version = "1", default-features = false }
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
 # optional dependencies
-ed25519-dalek = { version = "3.0.0-rc.1", optional = true, features = ["rand_core"] }
+ed25519-dalek = { version = "3", optional = true, features = ["rand_core"] }
 hmac = { version = "0.13", optional = true }
-k256 = { version = "0.14.0-rc.15", optional = true, features = ["ecdsa", "sha256"] }
+k256 = { version = "0.14", optional = true, features = ["ecdsa", "sha256"] }
 pbkdf2 = { version = "0.13", optional = true, default-features = false, features = ["hmac"] }
 serde_json = { version = "1", optional = true }
 rusb = { version = "0.9.4", optional = true }
 tiny_http = { version = "0.12", optional = true }
-x509-cert = { version = "0.3.0-rc.4", features = ["builder", "hazmat"], optional = true }
+x509-cert = { version = "0.3", features = ["builder", "hazmat"], optional = true }
 
 [dev-dependencies]
-ed25519-dalek = "3.0.0-rc.1"
+ed25519-dalek = "3"
 hex-literal = "1"
 once_cell = "1"
 rsa = { version = "0.10.0-rc.18", features = ["sha1", "sha2"] }
-p256 = { version = "0.14.0-rc.15", features = ["ecdsa"] }
-p384 = { version = "0.14.0-rc.15", features = ["ecdsa"] }
-p521 = { version = "0.14.0-rc.15", features = ["ecdsa"] }
-x509-cert = { version = "0.3.0-rc.4", features = ["builder"] }
+p256 = { version = "0.14", features = ["ecdsa"] }
+p384 = { version = "0.14", features = ["ecdsa"] }
+p521 = { version = "0.14", features = ["ecdsa"] }
+x509-cert = { version = "0.3", features = ["builder"] }
 
 [features]
 default = ["http", "passwords", "setup"]


### PR DESCRIPTION
Six dependencies were pinned to pre-release version requirements even though stable releases have since shipped to crates.io. This moves those requirements onto the stable series.

| Crate | Before | After |
|---|---|---|
| `ed25519-dalek` | `3.0.0-rc.1` | `3` |
| `k256` | `0.14.0-rc.15` | `0.14` |
| `p256` | `0.14.0-rc.15` | `0.14` |
| `p384` | `0.14.0-rc.15` | `0.14` |
| `p521` | `0.14.0-rc.15` | `0.14` |
| `x509-cert` | `0.3.0-rc.4` | `0.3` |

Resolution additionally pulls `curve25519-dalek` 5.0.0, `primeorder` 0.14.0 and `wnaf` 0.14.0 to their stable releases. **No source changes were required.**

### Why this matters for 0.43.0

Publishing a release whose manifest names pre-release requirements pins every downstream consumer (tmkms among them) to pre-releases. This removes six of the eight such requirements.

After this lands the only remaining pre-release requirements are:

- `rsa` 0.10.0-rc.18 — latest stable is 0.9.10
- `ccm` 0.6.0-rc.3 — latest stable is 0.5.0

The other pre-release crates still in the resolved graph (`aead`, `ctr`, `pkcs1`) arrive transitively through those two, so `rsa` and `ccm` are the sole remaining blockers for tagging a stable 0.43.0.

### Verification

Full CI matrix run locally against this branch:

```
fmt: PASS   clippy (--all-features -D warnings): PASS   doc (RUSTDOCFLAGS=-D warnings): PASS
build --no-default-features: PASS      build --features=passwords: PASS
build --features=usb: PASS             build --all-features @ 1.85.0 (MSRV): PASS
cargo test --features=mockhsm,secp256k1,untested: 54 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
