### PR TITLE
MSRV 1.88; resolve three open security advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.85.0 # MSRV
+          - 1.88.0 # MSRV
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -34,7 +34,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.85.0 # MSRV
+          - 1.88.0 # MSRV
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85.0 # pinned to prevent CI breakages
+          toolchain: 1.88.0 # pinned to prevent CI breakages
           components: clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,15 +247,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -354,14 +355,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -541,9 +543,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce7f1aa9a24c53c6572d8017c8c1ceb5d44c6071ff68c9912860fa4d262101"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
  "ecdsa",
@@ -619,9 +621,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -632,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -646,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct 1.0.0",
  "ecdsa",
@@ -735,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478aa2e499c7164b21b4c5e8610018e5b83a284da5f9e0896907dd4749cd76c9"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "once_cell",
@@ -1244,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "wnaf"
-version = "0.14.0-rc.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfae175ab8f55e3c604de329bf66f628274c2cda893923670a73ebd1958ead2"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
  "ff",
  "group",
@@ -1255,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.3.0-rc.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e21aad3a769f25f3d2d0cbf30ea8b50a1d602354bd6ab687fad112821608ba6"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
  "const-oid",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "const-oid"
@@ -308,11 +308,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -600,9 +599,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -774,9 +773,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom",
@@ -1004,29 +1003,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 categories = ["cryptography", "hardware-support"]
 keywords = ["ecdsa", "ed25519", "hmac", "hsm", "yubikey"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
 aes = { version = "0.9", features = ["zeroize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ digest = { version = "0.11", default-features = false }
 ecdsa = { version = "0.17", default-features = false, features = ["pkcs8"] }
 ed25519 = "3"
 log = "0.4"
-p256 = { version = "0.14.0-rc.15", default-features = false, features = ["ecdsa", "sha256"] }
-p384 = { version = "0.14.0-rc.15", default-features = false, features = ["ecdsa", "sha384"] }
-p521 = { version = "0.14.0-rc.15", default-features = false, features = ["ecdsa", "sha512"] }
+p256 = { version = "0.14", default-features = false, features = ["ecdsa", "sha256"] }
+p384 = { version = "0.14", default-features = false, features = ["ecdsa", "sha384"] }
+p521 = { version = "0.14", default-features = false, features = ["ecdsa", "sha512"] }
 serde = { version = "1", features = ["serde_derive"] }
 rand = { version = "0.10" }
 rand_core = { version = "0.10" }
@@ -45,24 +45,24 @@ uuid = { version = "1", default-features = false }
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
 # optional dependencies
-ed25519-dalek = { version = "3.0.0-rc.1", optional = true, features = ["rand_core"] }
+ed25519-dalek = { version = "3", optional = true, features = ["rand_core"] }
 hmac = { version = "0.13", optional = true }
-k256 = { version = "0.14.0-rc.15", optional = true, features = ["ecdsa", "sha256"] }
+k256 = { version = "0.14", optional = true, features = ["ecdsa", "sha256"] }
 pbkdf2 = { version = "0.13", optional = true, default-features = false, features = ["hmac"] }
 serde_json = { version = "1", optional = true }
 rusb = { version = "0.9.4", optional = true }
 tiny_http = { version = "0.12", optional = true }
-x509-cert = { version = "0.3.0-rc.4", features = ["builder", "hazmat"], optional = true }
+x509-cert = { version = "0.3", features = ["builder", "hazmat"], optional = true }
 
 [dev-dependencies]
-ed25519-dalek = "3.0.0-rc.1"
+ed25519-dalek = "3"
 hex-literal = "1"
 once_cell = "1"
 rsa = { version = "0.10.0-rc.18", features = ["sha1", "sha2"] }
-p256 = { version = "0.14.0-rc.15", features = ["ecdsa"] }
-p384 = { version = "0.14.0-rc.15", features = ["ecdsa"] }
-p521 = { version = "0.14.0-rc.15", features = ["ecdsa"] }
-x509-cert = { version = "0.3.0-rc.4", features = ["builder"] }
+p256 = { version = "0.14", features = ["ecdsa"] }
+p384 = { version = "0.14", features = ["ecdsa"] }
+p521 = { version = "0.14", features = ["ecdsa"] }
+x509-cert = { version = "0.3", features = ["builder"] }
 
 [features]
 default = ["http", "passwords", "setup"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -846,7 +846,7 @@ impl Client {
         if let Err(e) = &result {
             if *e.kind() == session::ErrorKind::ProtocolError {
                 // real devices can send protocol errors when the request has been accepted
-                debug!("error sending reset command: {}", e);
+                debug!("error sending reset command: {e}");
             } else {
                 // other errors, such as insufficient permissions, should be propagated
                 result?;
@@ -915,7 +915,7 @@ impl Client {
                             e
                         )
                     } else {
-                        debug!("error reconnecting to HSM: {}", e);
+                        debug!("error reconnecting to HSM: {e}");
                         thread::sleep(Duration::from_millis(DEVICE_POLL_INTERVAL_MS))
                     }
                 }

--- a/src/connector/usb/connection.rs
+++ b/src/connector/usb/connection.rs
@@ -108,8 +108,7 @@ fn recv_message(
             // retry the read for `MAX_RECV_RETRIES` attempts
             Err(rusb::Error::Io) => {
                 debug!(
-                    "I/O error during USB bulk message receive, retrying ({} attempts remaining)",
-                    attempts_remaining
+                    "I/O error during USB bulk message receive, retrying ({attempts_remaining} attempts remaining)"
                 );
             }
             // All other errors we return immediately

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -278,7 +278,7 @@ fn export_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
     {
         Ok(ciphertext) => ExportWrappedResponse(wrap::Message { nonce, ciphertext }).serialize(),
         Err(e) => {
-            debug!("error wrapping object: {}", e);
+            debug!("error wrapping object: {e}");
             device::ErrorKind::InvalidCommand.into()
         }
     }
@@ -466,7 +466,7 @@ fn import_wrapped(state: &mut State, cmd_data: &[u8]) -> response::Message {
         }
         .serialize(),
         Err(e) => {
-            debug!("error unwrapping object: {}", e);
+            debug!("error unwrapping object: {e}");
             device::ErrorKind::InvalidCommand.into()
         }
     }
@@ -836,7 +836,7 @@ fn sign_pkcs1v15(state: &State, cmd_data: &[u8]) -> response::Message {
                     sign_pkcs1v15_prehash::<Sha512>(private_key, command.digest.as_ref())
                 }
                 len => {
-                    debug!("invalid digest length: {}", len);
+                    debug!("invalid digest length: {len}");
                     return device::ErrorKind::InvalidCommand.into();
                 }
             };

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -64,10 +64,7 @@ pub fn init_with_profile(client: Client, profile: Profile) -> Result<Report, Err
             )
         })?;
 
-    info!(
-        "installed temporary setup authentication key into slot {}",
-        setup_auth_key_id
-    );
+    info!("installed temporary setup authentication key into slot {setup_auth_key_id}");
 
     let connector = client.connector().clone();
 
@@ -85,10 +82,7 @@ pub fn init_with_profile(client: Client, profile: Profile) -> Result<Report, Err
         )
     })?;
 
-    warn!(
-        "deleting default authentication key from slot {}",
-        DEFAULT_AUTHENTICATION_KEY_ID
-    );
+    warn!("deleting default authentication key from slot {DEFAULT_AUTHENTICATION_KEY_ID}");
 
     client
         .delete_object(
@@ -107,10 +101,7 @@ pub fn init_with_profile(client: Client, profile: Profile) -> Result<Report, Err
     let report = profile.provision(&client)?;
 
     if profile.delete_setup_auth_key {
-        warn!(
-            "deleting temporary setup authentication key from slot {}",
-            setup_auth_key_id
-        );
+        warn!("deleting temporary setup authentication key from slot {setup_auth_key_id}");
         client
             .delete_object(setup_auth_key_id, object::Type::AuthenticationKey)
             .map_err(|e| {

--- a/src/setup/profile.rs
+++ b/src/setup/profile.rs
@@ -114,10 +114,7 @@ impl Profile {
         let report = Report::new(client.device_info()?.serial_number);
 
         if let Some(report_object_id) = self.report_object_id {
-            info!(
-                "storing provisioning report in opaque object 0x{:x}",
-                report_object_id
-            );
+            info!("storing provisioning report in opaque object 0x{report_object_id:x}");
             report.store(client, report_object_id)?;
         }
 

--- a/tests/command/decrypt_oaep.rs
+++ b/tests/command/decrypt_oaep.rs
@@ -15,7 +15,7 @@ fn rsa_decrypt_oaep_test() {
 
     let raw_public_key = client
         .get_public_key(TEST_KEY_ID)
-        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+        .unwrap_or_else(|err| panic!("error getting public key: {err}"));
 
     assert_eq!(raw_public_key.algorithm, asymmetric::Algorithm::Rsa2048);
     assert_eq!(raw_public_key.bytes.len(), 256);

--- a/tests/command/sign_attestation_certificate.rs
+++ b/tests/command/sign_attestation_certificate.rs
@@ -14,7 +14,7 @@ fn attest_asymmetric_test() {
 
     let certificate = client
         .sign_attestation_certificate(TEST_KEY_ID, None)
-        .unwrap_or_else(|err| panic!("error getting attestation certificate: {}", err));
+        .unwrap_or_else(|err| panic!("error getting attestation certificate: {err}"));
 
     // TODO: more tests, e.g. test that the certificate validates
     assert!(certificate.len() > EC_P256_PUBLIC_KEY_SIZE);

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -215,7 +215,7 @@ fn ecdsa_nistp384_import_wrapped() {
             capabilities,
             delegated_capabilities,
             algorithm,
-            &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         )
         .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 
@@ -296,7 +296,7 @@ fn ecdsa_nistp384_put_key() {
             capabilities,
             delegated_capabilities,
             algorithm,
-            &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         )
         .unwrap_or_else(|err| panic!("error generating wrap key: {err}"));
 


### PR DESCRIPTION
Stacked on #679 — please merge that first. The diff below is against `deps/consolidate-to-stable`.

Bumps MSRV from **1.85 to 1.88** in order to take patched releases of three dependencies with open Dependabot advisories.

### Advisories resolved

| Severity | Crate | Advisory | Fix |
|---|---|---|---|
| medium | `cmov` | [GHSA-3rjw-m598-pq24](https://github.com/advisories/GHSA-3rjw-m598-pq24) — Cmov/CmovEq on aarch64 can produce wrong results if high bits of registers are set | 0.5.2 -> 0.5.4 |
| medium | `time` | [GHSA-r6v5-fh4h-64xc](https://github.com/advisories/GHSA-r6v5-fh4h-64xc) — stack exhaustion DoS | 0.3.44 -> 0.3.55 |
| low | `rand` | [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) — unsound with a custom logger using `rand::rng()` | 0.10.0 -> 0.10.2 |

The `cmov` one is the notable one: it arrives via `crypto-bigint` -> `crypto-primes` -> `rsa`, so it sits in the RSA constant-time arithmetic path rather than somewhere incidental.

### Why 1.88 specifically

1.88 is the exact floor, not a round-up. `time` 0.3.47 — the first release outside the advisory's vulnerable range (`>= 0.3.6, < 0.3.47`) — declares `rust-version = "1.88.0"`. Nothing else in the resolved graph requires more; the next highest is 1.87 (`wit-bindgen`, a build-time transitive).

This also unblocks #656, which independently wants 1.88 for `slice::as_chunks`.

### Supersedes #649

#649 bumped `time` to 0.3.46, which is **still inside the vulnerable range** and already required rustc 1.88. It should be closed in favour of this.

### Clippy pin

The clippy CI job is pinned to the MSRV toolchain (`# pinned to prevent CI breakages`). Moving that pin to 1.88 enables clippy's `uninlined_format_args` lint, producing 26 findings. Applied mechanically via `cargo clippy --fix` — `debug!("...: {}", e)` becomes `debug!("...: {e}")`. No behavioral change.

### Verification

Full CI matrix run locally at both stable and the new MSRV:

```
fmt: PASS                          doc (RUSTDOCFLAGS=-D warnings): PASS
clippy @1.88 (CI job): PASS        clippy @1.88 --all-targets: PASS
build --no-default-features @1.88: PASS
build --features=passwords @1.88:  PASS
build --features=usb @1.88:        PASS
cargo test --features=mockhsm,secp256k1,untested @1.88: 54 passed, 0 failed
```

Confirmed resolved versions meet the patched thresholds: `cmov` 0.5.4, `rand` 0.10.2, `time` 0.3.55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
