### PR TITLE
Close sessions on Drop (supersedes #677)

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -29,10 +29,7 @@ use crate::{
     device, response,
     serialization::deserialize,
 };
-use std::{
-    panic::{self, AssertUnwindSafe},
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 /// Timeout fuzz factor: to avoid races/skew with the YubiHSM's clock,
 /// we consider sessions to be timed out slightly earlier than the actual
@@ -125,6 +122,39 @@ impl Session {
         let idle_time = Instant::now().duration_since(self.last_active);
         let timeout_with_fuzz = self.timeout.duration() - TIMEOUT_FUZZ_FACTOR;
         idle_time >= timeout_with_fuzz
+    }
+
+    /// Close this session, telling the HSM to release its resources rather
+    /// than waiting for the session to time out.
+    ///
+    /// Sessions are also closed automatically on [`Drop`], so calling this is
+    /// only necessary when you want to observe any error that occurs while
+    /// closing. Closing an already-closed or timed-out session is a no-op.
+    ///
+    /// This is reachable through [`Client::session`][crate::Client::session],
+    /// which derefs mutably to `Session`:
+    ///
+    /// ```no_run
+    /// # fn example(client: &yubihsm::Client) -> Result<(), yubihsm::client::Error> {
+    /// client.session()?.close()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn close(&mut self) -> Result<(), Error> {
+        // Only attempt to close the session if we have an active secure
+        // channel and our session hasn't already timed out
+        if self.secure_channel.is_none() || self.is_timed_out() {
+            return Ok(());
+        }
+
+        session_debug!(self, "closing session");
+        let result = self.send_command(&CloseSessionCommand {});
+
+        // Whether or not the HSM acknowledged it, this channel is finished.
+        // Clearing it also stops the `Drop` handler from trying again.
+        self.abort();
+
+        result.map(|_| ())
     }
 
     /// Abort this session, terminating it without closing it
@@ -268,34 +298,21 @@ impl Session {
 }
 
 impl Drop for Session {
-    /// Make a best effort to close the session if it's still healthy
+    /// Make a best effort to close the session if it's still healthy.
+    ///
+    /// Without this, sessions are only released when the HSM times them out,
+    /// which exhausts the device's limited pool of concurrent sessions.
     fn drop(&mut self) {
-        // Only attempt to close the session if we have an active secure
-        // channel and our session hasn't already timed out
-        if self.secure_channel.is_none() || self.is_timed_out() {
-            return;
-        }
-
-        session_debug!(self, "closing dropped session");
-
-        // TODO: ensure we're really unwind safe.
-        // This should still be better than panicking in a drop handler, hopefully
-        let result = panic::catch_unwind(AssertUnwindSafe(|| {
-            self.send_command(&CloseSessionCommand {}).unwrap()
-        }));
-
-        if let Err(err) = result {
-            // Attempt to extract the error message from the `Any` returned from `catch_unwind`
-            let msg = err
-                .downcast_ref::<String>()
-                .map(AsRef::as_ref)
-                .or_else(|| err.downcast_ref::<&str>().cloned())
-                .unwrap_or("unknown cause!");
-
+        // `close` already short-circuits on a closed or timed-out session.
+        //
+        // Errors are logged rather than propagated: a destructor has nowhere
+        // to return them, and failing to notify the HSM is recoverable — the
+        // session times out on its own.
+        if let Err(err) = self.close() {
             error!(
-                "session={} panic closing dropped session: {}",
+                "session={} error closing dropped session: {}",
                 self.id.to_u8(),
-                msg
+                err
             );
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,7 +29,10 @@ use crate::{
     device, response,
     serialization::deserialize,
 };
-use std::time::{Duration, Instant};
+use std::{
+    panic::{self, AssertUnwindSafe},
+    time::{Duration, Instant},
+};
 
 /// Timeout fuzz factor: to avoid races/skew with the YubiHSM's clock,
 /// we consider sessions to be timed out slightly earlier than the actual
@@ -122,19 +125,6 @@ impl Session {
         let idle_time = Instant::now().duration_since(self.last_active);
         let timeout_with_fuzz = self.timeout.duration() - TIMEOUT_FUZZ_FACTOR;
         idle_time >= timeout_with_fuzz
-    }
-
-    /// Close this session, consuming it in the process.
-    pub fn close(mut self) -> Result<(), Error> {
-        // Only attempt to close the session if we have an active secure
-        // channel and our session hasn't already timed out
-        if self.secure_channel.is_none() || self.is_timed_out() {
-            return Ok(());
-        }
-
-        session_debug!(self, "closing session");
-        self.send_command(&CloseSessionCommand {})?;
-        Ok(())
     }
 
     /// Abort this session, terminating it without closing it
@@ -274,5 +264,39 @@ impl Session {
         self.secure_channel
             .as_mut()
             .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed").into())
+    }
+}
+
+impl Drop for Session {
+    /// Make a best effort to close the session if it's still healthy
+    fn drop(&mut self) {
+        // Only attempt to close the session if we have an active secure
+        // channel and our session hasn't already timed out
+        if self.secure_channel.is_none() || self.is_timed_out() {
+            return;
+        }
+
+        session_debug!(self, "closing dropped session");
+
+        // TODO: ensure we're really unwind safe.
+        // This should still be better than panicking in a drop handler, hopefully
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            self.send_command(&CloseSessionCommand {}).unwrap()
+        }));
+
+        if let Err(err) = result {
+            // Attempt to extract the error message from the `Any` returned from `catch_unwind`
+            let msg = err
+                .downcast_ref::<String>()
+                .map(AsRef::as_ref)
+                .or_else(|| err.downcast_ref::<&str>().cloned())
+                .unwrap_or("unknown cause!");
+
+            error!(
+                "session={} panic closing dropped session: {}",
+                self.id.to_u8(),
+                msg
+            );
+        }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -303,6 +303,20 @@ impl Drop for Session {
     /// Without this, sessions are only released when the HSM times them out,
     /// which exhausts the device's limited pool of concurrent sessions.
     fn drop(&mut self) {
+        // Never touch the transport while unwinding.
+        //
+        // `Connector::send_message` locks with `lock().unwrap()`. If a panic
+        // poisoned that mutex — including a panic raised *while* it was held —
+        // closing here would panic a second time inside a destructor, which
+        // aborts the process. A recoverable panic must not become an abort just
+        // because a session went out of scope on the way out.
+        //
+        // The session is still released: the HSM times it out on its own.
+        if std::thread::panicking() {
+            self.abort();
+            return;
+        }
+
         // `close` already short-circuits on a closed or timed-out session.
         //
         // Errors are logged rather than propagated: a destructor has nowhere

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16,6 +16,9 @@ mod ed25519;
 /// Rsa tests
 mod rsa;
 
+/// Session lifecycle tests
+mod session;
+
 /// Cryptographic test vectors taken from standards documents
 mod test_vectors;
 

--- a/tests/session/mod.rs
+++ b/tests/session/mod.rs
@@ -1,0 +1,28 @@
+//! Session lifecycle tests
+
+/// Sessions must be released back to the HSM when dropped.
+///
+/// The device supports a limited number of concurrent sessions (16). Before
+/// sessions were closed on `Drop`, repeatedly creating and dropping clients
+/// exhausted that pool and further opens failed with `SessionsFull` — see
+/// <https://github.com/iqlusioninc/yubihsm.rs/issues/495>.
+///
+/// The connector is cloned rather than recreated so that every client talks to
+/// the *same* HSM and its session pool actually accumulates; with a fresh HSM
+/// per iteration this test would pass even with no `Drop` handler at all.
+#[test]
+fn sessions_are_released_on_drop() {
+    let connector = crate::create_hsm_connector();
+
+    for i in 0..40 {
+        let client = yubihsm::Client::open(connector.clone(), Default::default(), true)
+            .unwrap_or_else(|err| panic!("failed opening client #{i}: {err}"));
+
+        // Exercise the session so it is genuinely established, not just created.
+        client
+            .device_info()
+            .unwrap_or_else(|err| panic!("failed talking to HSM on client #{i}: {err}"));
+
+        drop(client);
+    }
+}

--- a/tests/session/mod.rs
+++ b/tests/session/mod.rs
@@ -26,3 +26,24 @@ fn sessions_are_released_on_drop() {
         drop(client);
     }
 }
+
+/// Dropping a live session while unwinding must not turn a recoverable panic
+/// into a process abort.
+///
+/// `Connector::send_message` locks with `lock().unwrap()`, so closing from a
+/// destructor during unwinding risks a second panic and an abort. If that
+/// happened this test would not merely fail — the whole test binary would die,
+/// taking the other tests with it.
+#[test]
+#[should_panic(expected = "unwind with a live session")]
+fn dropping_a_session_while_unwinding_does_not_abort() {
+    let connector = crate::create_hsm_connector();
+
+    let client =
+        yubihsm::Client::open(connector, Default::default(), true).expect("failed opening client");
+
+    client.device_info().expect("failed talking to HSM");
+
+    // `client` is still alive, so its `Session` is dropped during unwinding.
+    panic!("unwind with a live session");
+}


### PR DESCRIPTION
Supersedes #677, which was auto-closed when the fork was deleted. dvzrv's commit is preserved with original authorship; my changes are a separate commit on top so the two are reviewable apart.

Fixes: #495

## What dvzrv's commit does

Reverts #265, restoring session auto-close on `Drop`.

The premise is correct and maintainer-confirmed — from #495:

> While it's possible to revert #265 since **the actual culprit was fixed in #273**, it's lead me to question the wisdom of executing complicated code in drop handlers. [...] I guess we could try reverting it and see if any problems arise.

Verified: #265 removed the handler 2021-11-17, #273 landed the actual fix 12 days later on 2021-11-29.

## What I changed

**1. No unwinding machinery in the destructor.** The revert reintroduced exactly the pattern objected to:

```rust
panic::catch_unwind(AssertUnwindSafe(|| {
    self.send_command(&CloseSessionCommand {}).unwrap()
}))
```

`send_command` returns a `Result`. That `.unwrap()` turned every ordinary I/O failure — disconnected connector, timed-out device — into a panic purely so `catch_unwind` could catch it again. The handler now matches on the error and logs it; `catch_unwind` and the `panic` imports are gone entirely.

**2. Restored `Session::close`, made usable.** The consuming `close(self)` was unreachable in practice, because `Client::session` hands out a `session::Guard<'_>`:

```
error[E0507]: cannot move out of dereference of `Guard<'_>`
```

That's what dvzrv hit. `Guard` implements `DerefMut`, so taking `&mut self` makes `client.session()?.close()?` work for callers who want to observe close errors. `close` clears the secure channel on the way out, so `Drop` won't close twice.

**3. Regression test for #495.** Opens and drops 40 clients against one HSM; the device allows 16 concurrent sessions, so it only passes if dropped sessions are handed back.

Verified non-vacuous — with the `Drop` body disabled:

```
test session::sessions_are_released_on_drop ... FAILED
panicked at src/mockhsm/state.rs:60:33:
session ID exceeds the maximum allowed: 17 (max 16)
```

Worth noting my first attempt at this test was vacuous: it called `create_hsm_connector()` per iteration, giving each client a *fresh* MockHSM so the pool never accumulated, and it passed with the handler disabled. It now clones one connector.

Also note this makes the existing doc at `src/session.rs:44` true again — it has claimed sessions are closed on `Drop` since 2021, which has been false since #265.

## Verification

```
cargo test --features=mockhsm,secp256k1,untested: 60 passed, 0 failed
fmt: PASS   clippy --all-features -D warnings: PASS   doc: PASS
build --no-default-features: PASS   build --all-features @1.88 (MSRV): PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
