### PR TITLE
Make Label safer; derive Clone/Debug/serde for Filter (supersedes #672)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -561,7 +561,7 @@ impl Client {
         let mut filter_bytes = vec![];
 
         for filter in filters {
-            filter.serialize(&mut filter_bytes)?;
+            filter.to_wire(&mut filter_bytes)?;
         }
 
         Ok(self.send_command(ListObjectsCommand(filter_bytes))?.0)

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -485,7 +485,7 @@ fn list_objects(state: &State, cmd_data: &[u8]) -> response::Message {
     let mut filters = vec![];
 
     while cursor.position() < len {
-        filters.push(object::Filter::deserialize(&mut cursor).unwrap());
+        filters.push(object::Filter::from_wire(&mut cursor).unwrap());
     }
 
     let list_entries = state

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -131,7 +131,9 @@ impl Default for Objects {
             length: authentication::key::SIZE as u16,
             sequence: 1,
             origin: Origin::Imported,
-            label: DEFAULT_AUTHENTICATION_KEY_LABEL.into(),
+            label: DEFAULT_AUTHENTICATION_KEY_LABEL.parse().expect(
+                "the default authentication key label to be less than or equal to 40 bytes",
+            ),
         };
 
         let authentication_key_payload = Payload::AuthenticationKey(authentication::Key::default());
@@ -158,7 +160,9 @@ impl Default for Objects {
             length: 0,
             sequence: 0,
             origin: Origin::Generated,
-            label: "MOCKHSM ATTESTATION KEY".into(),
+            label: "MOCKHSM ATTESTATION KEY".parse().expect(
+                "the default mockhsm attestation key label to be less than or equal to 40 bytes",
+            ),
         };
         let attestation_cert_info = Info {
             object_id: DEFAULT_ATTESTATION_KEY_ID,
@@ -170,7 +174,9 @@ impl Default for Objects {
             length: 0,
             sequence: 0,
             origin: Origin::Generated,
-            label: "MOCKHSM ATTESTATION CERT".into(),
+            label: "MOCKHSM ATTESTATION CERT".parse().expect(
+                "the default mockhsm attestation cert label to be less than or equal to 40 bytes",
+            ),
         };
 
         let attestation_cert_payload = Payload::Opaque(

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -1,5 +1,7 @@
 //! Filters for selecting objects in the list object command
 
+use serde::{Deserialize, Serialize};
+
 use crate::{algorithm::Algorithm, capability::Capability, client, domain::Domain, object};
 use std::io::Write;
 
@@ -10,7 +12,7 @@ use {
 };
 
 /// Filters to apply when listing objects
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Filter {
     /// Filter objects by algorithm
     Algorithm(Algorithm),

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -64,8 +64,14 @@ impl Filter {
         }
     }
 
-    // TODO: replace this with serde
-    pub(crate) fn serialize<W: Write>(&self, mut writer: W) -> Result<W, client::Error> {
+    /// Encode this filter in the HSM's wire format for `ListObjects`.
+    ///
+    /// This is **not** the derived [`Serialize`] impl. `Filter` carries two
+    /// unrelated encodings: this one, which the device defines (a tag byte
+    /// followed by the payload), and the serde impls, which exist so filters
+    /// can appear in user-facing config. They are not interchangeable, hence
+    /// the distinct names.
+    pub(crate) fn to_wire<W: Write>(&self, mut writer: W) -> Result<W, client::Error> {
         writer.write_all(&[self.tag()])?;
 
         match *self {
@@ -82,9 +88,12 @@ impl Filter {
         Ok(writer)
     }
 
-    // TODO: replace this with serde
+    /// Decode a filter from the HSM's wire format.
+    ///
+    /// Counterpart to [`Filter::to_wire`]; see the note there on why this is
+    /// not the derived [`Deserialize`] impl.
     #[cfg(feature = "mockhsm")]
-    pub(crate) fn deserialize<R: Read>(mut reader: R) -> Result<Self, client::Error> {
+    pub(crate) fn from_wire<R: Read>(mut reader: R) -> Result<Self, client::Error> {
         let tag = read_byte!(reader);
 
         Ok(match tag {

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -10,6 +10,7 @@ use {
 };
 
 /// Filters to apply when listing objects
+#[derive(Clone, Debug)]
 pub enum Filter {
     /// Filter objects by algorithm
     Algorithm(Algorithm),

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -84,12 +84,6 @@ impl FromStr for Label {
     }
 }
 
-impl<'a> From<&'a str> for Label {
-    fn from(s: &'a str) -> Self {
-        Self::from_str(s).unwrap()
-    }
-}
-
 impl PartialEq for Label {
     fn eq(&self, other: &Self) -> bool {
         self.0[..] == other.0[..]

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -14,6 +14,7 @@ pub const LABEL_SIZE: usize = 40;
 const INVALID_LABEL_STR_PLACEHOLDER: &str = "[INVALID UTF-8 CHARACTER IN LABEL]";
 
 /// Labels attached to objects
+#[derive(Clone)]
 pub struct Label(pub [u8; LABEL_SIZE]);
 
 impl Label {
@@ -46,12 +47,6 @@ impl Label {
 impl AsRef<[u8]> for Label {
     fn as_ref(&self) -> &[u8] {
         &self.0
-    }
-}
-
-impl Clone for Label {
-    fn clone(&self) -> Self {
-        Self::from_bytes(self.as_ref()).unwrap()
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,7 +49,9 @@ pub fn init_with_profile(client: Client, profile: Profile) -> Result<Report, Err
     client
         .put_authentication_key(
             setup_auth_key_id,
-            SETUP_KEY_LABEL.into(),
+            SETUP_KEY_LABEL
+                .parse()
+                .map_err(|_error| ErrorKind::LabelInvalid)?,
             Domain::all(),
             Capability::all(),
             Capability::all(),

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -76,7 +76,9 @@ impl Report {
         client
             .put_opaque(
                 report_object_id,
-                object::Label::from(REPORT_OBJECT_LABEL),
+                REPORT_OBJECT_LABEL
+                    .parse()
+                    .map_err(|_error| ErrorKind::LabelInvalid)?,
                 Domain::all(),
                 Capability::GET_OPAQUE,
                 opaque::Algorithm::Data,

--- a/src/wrap/message.rs
+++ b/src/wrap/message.rs
@@ -313,7 +313,9 @@ mod tests {
             0xcf,
             Capability::SIGN_ECDSA | Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED,
             Domain::DOM1,
-            "Signatory test key".into(),
+            "Signatory test key"
+                .parse()
+                .expect("label to be less than or equal to 40 bytes"),
             secret_key,
         )
         .expect("build message with ecdsa key");

--- a/tests/command/change_authentication_key.rs
+++ b/tests/command/change_authentication_key.rs
@@ -20,7 +20,9 @@ fn provision() -> yubihsm::Connector {
     admin
         .put_authentication_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             Capability::all(),
             Capability::all(),

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -19,7 +19,9 @@ fn wrap_key_test() {
     let key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -40,7 +42,9 @@ fn wrap_key_test() {
     client
         .generate_asymmetric_key(
             TEST_EXPORTED_KEY_ID,
-            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_EXPORTED_KEY_LABEL
+                .parse()
+                .expect("TEST_EXPORTED_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             exported_key_capabilities,
             exported_key_algorithm,
@@ -100,7 +104,9 @@ fn wrap_deserialize() {
     let key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -121,7 +127,9 @@ fn wrap_deserialize() {
     client
         .generate_asymmetric_key(
             TEST_EXPORTED_KEY_ID,
-            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_EXPORTED_KEY_LABEL
+                .parse()
+                .expect("TEST_EXPORTED_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             exported_key_capabilities,
             exported_key_algorithm,
@@ -167,7 +175,9 @@ fn wrap_deserialize_rsa() {
     let key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -188,7 +198,9 @@ fn wrap_deserialize_rsa() {
     client
         .generate_asymmetric_key(
             TEST_EXPORTED_KEY_ID,
-            TEST_EXPORTED_KEY_LABEL.into(),
+            TEST_EXPORTED_KEY_LABEL
+                .parse()
+                .expect("TEST_EXPORTED_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             exported_key_capabilities,
             exported_key_algorithm,

--- a/tests/command/generate_hmac_key.rs
+++ b/tests/command/generate_hmac_key.rs
@@ -14,7 +14,9 @@ fn hmac_key_test() {
     let key_id = client
         .generate_hmac_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             algorithm,

--- a/tests/command/generate_wrap_key.rs
+++ b/tests/command/generate_wrap_key.rs
@@ -18,7 +18,9 @@ fn wrap_key_test() {
     let key_id = client
         .generate_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,

--- a/tests/command/put_authentication_key.rs
+++ b/tests/command/put_authentication_key.rs
@@ -17,7 +17,9 @@ fn put_authentication_key() {
     let key_id = client
         .put_authentication_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,

--- a/tests/command/put_opaque.rs
+++ b/tests/command/put_opaque.rs
@@ -12,7 +12,9 @@ fn opaque_object_test() {
     let object_id = client
         .put_opaque(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             Capability::default(),
             opaque::Algorithm::Data,

--- a/tests/command/verify_hmac.rs
+++ b/tests/command/verify_hmac.rs
@@ -17,7 +17,9 @@ fn hmac_test_vectors() {
         let key_id = client
             .put_hmac_key(
                 TEST_KEY_ID,
-                TEST_KEY_LABEL.into(),
+                TEST_KEY_LABEL
+                    .parse()
+                    .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
                 TEST_DOMAINS,
                 capabilities,
                 algorithm,

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -69,7 +69,9 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
     client
         .generate_asymmetric_key(
             key_id,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             TEST_SIGNING_KEY_CAPABILITIES,
             alg,
@@ -188,7 +190,9 @@ fn ecdsa_nistp384_import_wrapped() {
         asymmetric_key_id,
         capabilities,
         TEST_DOMAINS,
-        TEST_SIGNING_KEY_LABEL.into(),
+        TEST_SIGNING_KEY_LABEL
+            .parse()
+            .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
         //delegated_capabilities,
         secret_key,
     )
@@ -210,7 +214,9 @@ fn ecdsa_nistp384_import_wrapped() {
     let _key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -262,7 +268,9 @@ fn ecdsa_nistp384_put_key() {
     let _key_id = client
         .put_asymmetric_key(
             asymmetric_key_id,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             asymmetric::Algorithm::EcP384,
@@ -291,7 +299,9 @@ fn ecdsa_nistp384_put_key() {
     let _key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,

--- a/tests/ed25519/mod.rs
+++ b/tests/ed25519/mod.rs
@@ -30,7 +30,9 @@ fn create_yubihsm_key(client: &Client) {
     client
         .generate_asymmetric_key(
             TEST_SIGNING_KEY_ID,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             TEST_SIGNING_KEY_CAPABILITIES,
             yubihsm::asymmetric::Algorithm::Ed25519,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -137,7 +137,9 @@ pub fn generate_asymmetric_key(
 
     match client.generate_asymmetric_key(
         TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
+        TEST_KEY_LABEL
+            .parse()
+            .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
         TEST_DOMAINS,
         capabilities,
         algorithm,
@@ -159,7 +161,9 @@ pub fn put_asymmetric_key<T: Into<Vec<u8>>>(
     let key_id = client
         .put_asymmetric_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             algorithm,

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -44,7 +44,9 @@ fn rsa_put_asymmetric_key() {
     let id = client
         .put_asymmetric_key(
             223,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             yubihsm::Capability::SIGN_PSS,
             yubihsm::asymmetric::Algorithm::Rsa2048,
@@ -71,7 +73,9 @@ fn rsa_import_export_wrapped_key() {
         asymmetric_key_id,
         Capability::EXPORTABLE_UNDER_WRAP | Capability::SIGN_PKCS,
         TEST_DOMAINS,
-        TEST_KEY_LABEL.into(),
+        TEST_KEY_LABEL
+            .parse()
+            .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
         key.clone(),
     )
     .expect("build message with RSA key");
@@ -88,7 +92,9 @@ fn rsa_import_export_wrapped_key() {
     let _key_id = client
         .put_wrap_key(
             TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
+            TEST_KEY_LABEL
+                .parse()
+                .expect("TEST_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_DOMAINS,
             capabilities,
             delegated_capabilities,
@@ -163,7 +169,9 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
     let _key = client
         .generate_asymmetric_key(
             key_id,
-            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_LABEL
+                .parse()
+                .expect("TEST_SIGNING_KEY_LABEL to be shorter than or equal to 40 bytes"),
             TEST_SIGNING_KEY_DOMAINS,
             yubihsm::Capability::SIGN_PSS
                 | yubihsm::Capability::SIGN_PKCS

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -6,7 +6,10 @@ use yubihsm::{
 };
 
 #[cfg(feature = "setup")]
-use yubihsm::setup::{Profile, Role};
+use yubihsm::{
+    object::Label,
+    setup::{Profile, Role},
+};
 
 const ROOT_KEY_ID: object::Id = 1;
 const ROOT_KEY_LABEL: &str = "root key";
@@ -16,7 +19,11 @@ const ROOT_KEY_LABEL: &str = "root key";
 fn setup_test() {
     let root_key = authentication::Key::random();
     let root_role = Role::new(Credentials::new(ROOT_KEY_ID, root_key))
-        .authentication_key_label(ROOT_KEY_LABEL)
+        .authentication_key_label(
+            ROOT_KEY_LABEL
+                .parse::<Label>()
+                .expect("ROOT_KEY_LABEL to be equal to or shorter than 40 bytes"),
+        )
         .capabilities(Capability::all())
         .domains(Domain::all());
 


### PR DESCRIPTION
Supersedes #672, auto-closed when the fork was deleted. dvzrv's four commits are preserved with original authorship; my two are on top.

## What dvzrv's commits do

- Remove `From<&'a str> for Label`, which panicked on labels over 40 bytes, in favour of `parse()`.
- Replace `Label`'s hand-written `Clone` (which did `Self::from_bytes(self.as_ref()).unwrap()`) with a derive.
- Derive `Clone`, `Debug`, `Serialize`, `Deserialize` for `Filter`.

Both `Label` changes remove real panic paths from a public API. Removing the `From` impl is a breaking change, but 0.43.0 is a breaking release and the call-site churn buys the removal of a panic on untrusted input.

## What I changed

**1. Named the two `Filter` encodings apart.** Deriving serde left `Filter` carrying two unrelated, incompatible encodings under near-identical names: the inherent `serialize`/`deserialize` implement the device's `ListObjects` wire format (tag byte plus payload), while the derived impls exist so filters can appear in user-facing config.

`filter.serialize(w)` and `serde_json::to_string(&filter)` produce completely unrelated bytes, with nothing at the call site indicating which is meant. Renamed the inherent pair to `to_wire`/`from_wire` and documented on each why it is not the serde impl. Both are `pub(crate)`, so this is not a public API change; both call sites are updated.

**2. Fixed a call site that landed after this branch.** #664 merged after dvzrv wrote these commits and added a new `TEST_KEY_LABEL.into()`, so the integration target no longer compiled:

```
error[E0277]: the trait bound `yubihsm::object::Label: From<&str>` is not satisfied
  --> tests/command/change_authentication_key.rs:23:28
```

Converted to the same `parse().expect(...)` form used everywhere else.

## Verification

```
cargo test --features=mockhsm,secp256k1,untested: 58 passed, 0 failed
fmt: PASS   clippy --all-features -D warnings: PASS   clippy --all-targets: PASS   doc: PASS
build --all-features @1.88 (MSRV): PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
