### PR TITLE
Derive PartialOrd/Ord; order algorithms by wire tag (supersedes #665)

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -7,7 +7,14 @@ pub use self::error::{Error, ErrorKind};
 use crate::{asymmetric, authentication, ecdh, ecdsa, hmac, opaque, otp, rsa, template, wrap};
 
 /// Cryptographic algorithm types supported by the `YubiHSM 2`
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+///
+/// # Ordering
+///
+/// `Ord` follows the wire tag values from [`Algorithm::to_u8`], not the order
+/// the variants are declared in. Declaration order groups algorithms by family
+/// and bears no relation to the tag values, so deriving it would produce an
+/// arbitrary order that shifted whenever a family was added or moved.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Asymmetric algorithms
@@ -348,5 +355,74 @@ mod tests {
         for (tag, alg) in ALGORITHM_MAPPING {
             assert_eq!(*tag, alg.to_u8());
         }
+    }
+}
+
+impl Ord for Algorithm {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.to_u8().cmp(&other.to_u8())
+    }
+}
+
+impl PartialOrd for Algorithm {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod ordering_tests {
+    use super::*;
+
+    /// The `Ord` derives on algorithm enums follow *declaration* order, not
+    /// the wire tag values. Today those agree; reordering variants would
+    /// silently change the ordering of anything sorted or stored in a
+    /// `BTreeMap`, with no compile error.
+    ///
+    /// This locks the two together: for every byte a given enum accepts, the
+    /// derived order must be the same as the order of the tag values.
+    macro_rules! assert_ord_matches_wire {
+        ($ty:ty) => {{
+            let mut variants: Vec<$ty> = (u8::MIN..=u8::MAX)
+                .filter_map(|byte| <$ty>::from_u8(byte).ok())
+                .collect();
+            assert!(
+                !variants.is_empty(),
+                "{} accepted no tag bytes",
+                stringify!($ty)
+            );
+
+            let wire_order: Vec<u8> = variants.iter().map(|v| v.to_u8()).collect();
+            variants.sort();
+            let derived_order: Vec<u8> = variants.iter().map(|v| v.to_u8()).collect();
+
+            assert_eq!(
+                derived_order,
+                wire_order,
+                "`Ord` for {} disagrees with its wire tag order; a variant was \
+                 likely reordered. Either restore declaration order or implement \
+                 `Ord` explicitly via `to_u8`.",
+                stringify!($ty)
+            );
+        }};
+    }
+
+    #[test]
+    fn ord_matches_wire_tag_order() {
+        assert_ord_matches_wire!(Algorithm);
+        assert_ord_matches_wire!(asymmetric::Algorithm);
+        assert_ord_matches_wire!(authentication::Algorithm);
+        assert_ord_matches_wire!(ecdh::Algorithm);
+        assert_ord_matches_wire!(ecdsa::Algorithm);
+        assert_ord_matches_wire!(hmac::Algorithm);
+        assert_ord_matches_wire!(opaque::Algorithm);
+        assert_ord_matches_wire!(otp::Algorithm);
+        assert_ord_matches_wire!(rsa::Algorithm);
+        assert_ord_matches_wire!(rsa::mgf::Algorithm);
+        assert_ord_matches_wire!(rsa::oaep::Algorithm);
+        assert_ord_matches_wire!(rsa::pkcs1::Algorithm);
+        assert_ord_matches_wire!(rsa::pss::Algorithm);
+        assert_ord_matches_wire!(template::Algorithm);
+        assert_ord_matches_wire!(wrap::Algorithm);
     }
 }

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -7,7 +7,7 @@ pub use self::error::{Error, ErrorKind};
 use crate::{asymmetric, authentication, ecdh, ecdsa, hmac, opaque, otp, rsa, template, wrap};
 
 /// Cryptographic algorithm types supported by the `YubiHSM 2`
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Asymmetric algorithms

--- a/src/asymmetric/algorithm.rs
+++ b/src/asymmetric/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Asymmetric algorithms (RSA or ECC)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// 2048-bit RSA

--- a/src/authentication/algorithm.rs
+++ b/src/authentication/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for auth keys
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// YubiHSM AES PSK authentication

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -14,7 +14,7 @@ bitflags! {
     /// Object attributes specifying which operations are allowed to be performed
     ///
     /// <https://developers.yubico.com/YubiHSM2/Concepts/Capability.html>
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
     pub struct Capability: u64 {
         /// `derive-ecdh`: perform ECDH operation
         const DERIVE_ECDH = 0x800;

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -14,6 +14,13 @@ bitflags! {
     /// Object attributes specifying which operations are allowed to be performed
     ///
     /// <https://developers.yubico.com/YubiHSM2/Concepts/Capability.html>
+    /// # Ordering
+    ///
+    /// `Ord` compares the underlying bits, so that `Capability` can be used as a
+    /// key in ordered collections and sorted for stable display. The order is
+    /// **not** semantic: `a < b` does not mean `a` grants fewer capabilities than
+    /// `b`. Flag sets are only partially ordered by inclusion — use
+    /// [`contains`][Self::contains] to test that relation.
     #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
     pub struct Capability: u64 {
         /// `derive-ecdh`: perform ECDH operation

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -36,7 +36,7 @@ bitflags! {
     /// basis. For more information, see the Yubico documentation:
     ///
     /// <https://developers.yubico.com/YubiHSM2/Concepts/Domain.html>
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
     pub struct Domain: u16 {
         const DOM1 = 0x0001;
         const DOM2 = 0x0002;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -36,6 +36,13 @@ bitflags! {
     /// basis. For more information, see the Yubico documentation:
     ///
     /// <https://developers.yubico.com/YubiHSM2/Concepts/Domain.html>
+    /// # Ordering
+    ///
+    /// `Ord` compares the underlying bits, so that `Domain` can be used as a
+    /// key in ordered collections and sorted for stable display. The order is
+    /// **not** semantic: `a < b` does not mean `a` grants fewer domains than
+    /// `b`. Flag sets are only partially ordered by inclusion — use
+    /// [`contains`][Self::contains] to test that relation.
     #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
     pub struct Domain: u16 {
         const DOM1 = 0x0001;

--- a/src/ecdh/algorithm.rs
+++ b/src/ecdh/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Key exchange algorithms (a.k.a. Diffie-Hellman)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Elliptic Curve Diffie-Hellman (Weierstrass)

--- a/src/ecdsa/algorithm.rs
+++ b/src/ecdsa/algorithm.rs
@@ -7,7 +7,7 @@ use crate::{algorithm, asymmetric};
 use super::Secp256k1;
 
 /// Valid algorithms for asymmetric keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `ecdsa-sha1`

--- a/src/hmac/algorithm.rs
+++ b/src/hmac/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for HMAC keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `hmac-sha1`

--- a/src/opaque/algorithm.rs
+++ b/src/opaque/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for opaque data
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Arbitrary opaque data

--- a/src/otp/algorithm.rs
+++ b/src/otp/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for Yubico OTP (AES-based one time password) keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// Yubico OTP using AES-128

--- a/src/rsa/algorithm.rs
+++ b/src/rsa/algorithm.rs
@@ -5,7 +5,14 @@ use crate::algorithm;
 use digest::{const_oid::AssociatedOid, Digest};
 
 /// RSA algorithms (signing and encryption)
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+///
+/// # Ordering
+///
+/// `Ord` follows the wire tag values from [`Algorithm::to_u8`], not the order
+/// the variants are declared in. Deriving it would order `Oaep` (tags
+/// `0x19..=0x1c`) before `Pkcs1` (`0x01..=0x04`), which is arbitrary and would
+/// shift if the variants were ever rearranged.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Algorithm {
     /// RSA encryption with Optimal Asymmetric Encryption Padding (OAEP)
@@ -40,6 +47,18 @@ impl Algorithm {
             Algorithm::Pkcs1(alg) => alg.to_u8(),
             Algorithm::Pss(alg) => alg.to_u8(),
         }
+    }
+}
+
+impl Ord for Algorithm {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.to_u8().cmp(&other.to_u8())
+    }
+}
+
+impl PartialOrd for Algorithm {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/rsa/algorithm.rs
+++ b/src/rsa/algorithm.rs
@@ -5,7 +5,7 @@ use crate::algorithm;
 use digest::{const_oid::AssociatedOid, Digest};
 
 /// RSA algorithms (signing and encryption)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// RSA encryption with Optimal Asymmetric Encryption Padding (OAEP)

--- a/src/rsa/mgf.rs
+++ b/src/rsa/mgf.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Mask generating functions for RSASSA-PSS
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `mgf-sha1`

--- a/src/rsa/oaep/algorithm.rs
+++ b/src/rsa/oaep/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// RSA Optimal Asymmetric Encryption Padding (OAEP) algorithms
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `rsa-oaep-sha1`

--- a/src/rsa/pkcs1/algorithm.rs
+++ b/src/rsa/pkcs1/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// RSA PKCS#1v1.5: legacy algorithms
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `rsa-pkcs1-sha1`

--- a/src/rsa/pss/algorithm.rs
+++ b/src/rsa/pss/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// RSASSA-PSS algorithms
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `rsa-pss-sha1`

--- a/src/template/algorithm.rs
+++ b/src/template/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Template algorithms (for SSH)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// `template-ssh`

--- a/src/wrap/algorithm.rs
+++ b/src/wrap/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::algorithm;
 
 /// Valid algorithms for "wrap" (symmetric encryption/key wrapping) keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Algorithm {
     /// AES-128 in Counter with CBC-MAC (CCM) mode

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -77,6 +77,7 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
         .unwrap();
 }
 
+#[cfg(feature = "untested")]
 #[test]
 fn ecdsa_nistp256_sign_test() {
     let signer = create_signer::<NistP256>(201);


### PR DESCRIPTION
Supersedes #665, auto-closed when the fork was deleted. dvzrv's commits are preserved with original authorship; my change is on top.

Dropped one commit from the original branch — "Add missing use of trait `ecdsa::elliptic_curve::Generate`" — since #671 has landed that fix on main, as dvzrv anticipated in his comment there.

## What dvzrv's commits do

Derive `PartialOrd`/`Ord` for `Capability`, `Domain`, and the algorithm enums, plus a test-feature guard fix.

## What I changed

I flagged in review that the derived ordering could mislead. Writing a test to check that turned up an actual defect rather than a hypothetical one.

**Algorithm enums.** A derived `Ord` follows *declaration* order, which for these types has no relation to the wire tag values. I added a test asserting the two agree for every tag each enum accepts, and it failed immediately on two of them:

```
Algorithm       left: [9, 10, ..., 46, 47, 38, 24, 23, 43, ...]
               right: [1, 2, 3, ..., 45, 46, 47]

rsa::Algorithm  left: [25, 26, 27, 28, 1, 2, ...]
               right: [1, 2, ..., 25, 26, 27, 28]
```

`rsa::Algorithm` declares `Oaep` (tags `0x19..=0x1c`) before `Pkcs1` (`0x01..=0x04`), and the top-level `Algorithm` groups variants by family. Both would have sorted in an order that is an accident of source layout — and would have silently changed whenever a variant moved. Anything sorted for display, or keyed in a `BTreeMap`, would inherit that.

Both now implement `Ord` explicitly via `to_u8`, which is the only ordering these wire types have a real claim to. The remaining enums keep the derive — their declaration order does match — and the new test holds them to it, so this can't regress silently.

**Bitflags.** `Capability` and `Domain` order by their underlying bits. That's fine for `BTreeMap` keys and stable display, but it reads as though `a < b` means `a` grants fewer capabilities, which it does not — flag sets are only partially ordered by inclusion. Documented the distinction on both types and pointed at `contains` for the relation people will actually want.

## Verification

```
cargo test --features=mockhsm,secp256k1,untested: 59 passed, 0 failed
fmt: PASS   clippy --all-features -D warnings: PASS   doc: PASS
build --no-default-features: PASS   build --all-features @1.88 (MSRV): PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
