### PR TITLE
http: validate request paths; drop panicking &str conversion

### DIFF
--- a/src/connector/http/client/connection.rs
+++ b/src/connector/http/client/connection.rs
@@ -63,12 +63,10 @@ impl Connection {
     }
 
     /// Make an HTTP POST request to the given path
-    pub fn post<P: Into<PathBuf>>(
-        &self,
-        into_path: P,
-        body: &request::Body,
-    ) -> Result<response::Body, Error> {
-        let path = into_path.into();
+    pub fn post(&self, path: &str, body: &request::Body) -> Result<response::Body, Error> {
+        // Parsed rather than converted infallibly: `PathBuf` validates against
+        // request splitting, and that error has to reach the caller.
+        let path: PathBuf = path.parse()?;
         let mut headers = String::new();
 
         writeln!(headers, "POST {path} {HTTP_VERSION}\r")?;

--- a/src/connector/http/client/path.rs
+++ b/src/connector/http/client/path.rs
@@ -13,9 +13,35 @@ pub struct PathBuf(String);
 impl FromStr for PathBuf {
     type Err = Error;
 
-    /// Create a path from the given string
+    /// Create a path from the given string.
+    ///
+    /// The path is interpolated directly into the HTTP request line, so it is
+    /// validated here rather than at the point of use: a path containing CR or
+    /// LF would let a caller terminate the request line early and inject
+    /// arbitrary headers or a second request.
     fn from_str(path: &str) -> Result<Self, Error> {
-        // TODO: validate path
+        if path.is_empty() {
+            return Err(err!(ParseError, "empty HTTP path"));
+        }
+
+        if !path.starts_with('/') {
+            return Err(err!(ParseError, "HTTP path must start with '/': {}", path));
+        }
+
+        // Rejects CR and LF (request splitting) along with the other C0
+        // controls and DEL, none of which are legal in a request target.
+        if let Some(c) = path.chars().find(|c| c.is_ascii_control()) {
+            return Err(err!(
+                ParseError,
+                "HTTP path contains a control character: {:?}",
+                c
+            ));
+        }
+
+        if path.chars().any(|c| c == ' ') {
+            return Err(err!(ParseError, "HTTP path contains a space: {}", path));
+        }
+
         Ok(PathBuf(path.to_owned()))
     }
 }
@@ -32,8 +58,52 @@ impl Display for PathBuf {
     }
 }
 
-impl From<&str> for PathBuf {
-    fn from(path: &str) -> Self {
-        Self::from_str(path).unwrap()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_ordinary_paths() {
+        for path in ["/", "/connector/api", "/a/b?c=d&e=f", "/%20encoded"] {
+            assert!(
+                path.parse::<PathBuf>().is_ok(),
+                "should have accepted {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_request_splitting() {
+        // Each of these would otherwise terminate the request line early and
+        // inject a header or a second request.
+        for path in [
+            "/api\r\nX-Injected: 1",
+            "/api\nX-Injected: 1",
+            "/api\r",
+            "/api\n\r\nGET /admin HTTP/1.1",
+        ] {
+            assert!(
+                path.parse::<PathBuf>().is_err(),
+                "should have rejected {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_paths() {
+        for path in ["", "connector/api", "/api with space", "/api\0"] {
+            assert!(
+                path.parse::<PathBuf>().is_err(),
+                "should have rejected {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_path_actually_used_is_accepted() {
+        assert_eq!(
+            "/connector/api".parse::<PathBuf>().unwrap().as_ref(),
+            "/connector/api"
+        );
     }
 }


### PR DESCRIPTION
Generalizes the `Label` fix from #694. While checking whether that bug class had other members, the HTTP client turned out to have the identical shape.

## The pattern

#694 removed this from `object::Label` because it panicked on labels over 40 bytes:

```rust
impl From<&str> for Label {
    fn from(s: &'a str) -> Self { Self::from_str(s).unwrap() }
}
```

`src/connector/http/client/path.rs` had the same construct:

```rust
impl From<&str> for PathBuf {
    fn from(path: &str) -> Self { Self::from_str(path).unwrap() }
}
```

It could not panic — but only because the constructor was a stub:

```rust
fn from_str(path: &str) -> Result<Self, Error> {
    // TODO: validate path
    Ok(PathBuf(path.to_owned()))
}
```

So the trap was armed rather than sprung. Implementing that TODO silently converts an infallible trait impl into a panic on bad input, which is precisely how `Label` got there. **An infallible `From`/`Into` must not wrap a validating constructor** — the two are contradictory by construction.

## Why implement the TODO rather than delete the impl

The path is interpolated directly into the HTTP request line (`connection.rs:74`):

```rust
writeln!(headers, "POST {path} {HTTP_VERSION}\r")?;
```

A path containing CR or LF terminates the request line early and lets the caller append arbitrary headers, or a whole second request. Leaving a validating constructor that validates nothing would keep both the panic trap and the injection route open.

`from_str` now rejects control characters (covering CR/LF), spaces, empty paths, and paths without a leading `/`.

`Connection::post` now takes `&str` and parses it, rather than `P: Into<PathBuf>`, so the new error reaches the caller instead of panicking.

## Scope and severity, stated plainly

**Not currently exploitable.** The only call site passes the literal `"/connector/api"`, and before this commit no input could be rejected at all. `path` lives under `pub(super) mod client`, so none of this is a public API change. This closes a latent panic and an injection route before either can matter — it is not a live vulnerability fix.

## Verification

Tests cover ordinary paths, four request-splitting shapes, and the malformed cases. Proven non-vacuous — restoring the always-`Ok` body:

```
test rejects_request_splitting ... FAILED
test rejects_malformed_paths ... FAILED
test accepts_ordinary_paths ... ok
test the_path_actually_used_is_accepted ... ok
```

Full matrix:

```
fmt: PASS   clippy --all-features -D warnings: PASS   doc: PASS
build --no-default-features: PASS   --features=usb: PASS   --all-features @1.88 (MSRV): PASS
cargo test --features=mockhsm,secp256k1,untested: 62 passed, 0 failed
```

(`--features=http-server,usb` reports 47 failures both with and without this change — those tests require a physical device, `no YubiHSM 2 devices detected`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
