### PR TITLE
mockhsm: add Objects::replace for in-place key replacement

### DIFF
--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -561,29 +561,14 @@ fn change_authentication_key(
         return device::ErrorKind::InvalidCommand.into();
     }
 
-    // Preserve the existing metadata; only the key material changes.
-    let info = match state.objects.get(key_id, object::Type::AuthenticationKey) {
-        Some(obj) => obj.object_info.clone(),
-        None => {
-            debug!("no such authentication key: {key_id}");
-            return device::ErrorKind::ObjectNotFound.into();
-        }
-    };
-
-    // `Objects::put` asserts the slot is empty, so vacate it first.
-    state
-        .objects
-        .remove(key_id, object::Type::AuthenticationKey);
-    state.objects.put(
+    if !state.objects.replace(
         key_id,
         object::Type::AuthenticationKey,
-        info.algorithm,
-        info.label,
-        info.capabilities,
-        info.delegated_capabilities,
-        info.domains,
         &authentication_key.0,
-    );
+    ) {
+        debug!("no such authentication key: {key_id}");
+        return device::ErrorKind::ObjectNotFound.into();
+    }
 
     ChangeAuthenticationKeyResponse { key_id }.serialize()
 }

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -246,6 +246,29 @@ impl Objects {
         assert!(self.0.insert(handle, object).is_none());
     }
 
+    /// Replace the payload of an existing object, preserving its metadata.
+    ///
+    /// Returns `false` if nothing occupies that slot.
+    ///
+    /// Unlike [`Objects::put`], this does not assert the slot is empty --
+    /// replacing in place is the point. It models `ChangeAuthenticationKey`,
+    /// where the device swaps the key material and leaves the object's ID,
+    /// label, domains, capabilities and algorithm untouched.
+    ///
+    /// Because the algorithm is metadata, it is preserved rather than passed
+    /// in, and the replacement payload is parsed under it.
+    pub fn replace(&mut self, object_id: Id, object_type: Type, data: &[u8]) -> bool {
+        let Some(object) = self.0.get_mut(&Handle::new(object_id, object_type)) else {
+            return false;
+        };
+
+        let payload = Payload::new(object.object_info.algorithm, data);
+        object.object_info.length = payload.len();
+        object.payload = payload;
+
+        true
+    }
+
     /// Get an object
     pub fn get(&self, object_id: Id, object_type: Type) -> Option<&Object> {
         self.0.get(&Handle::new(object_id, object_type))
@@ -504,3 +527,67 @@ impl Objects {
 
 /// Iterator over objects
 pub(crate) type Iter<'a> = MapIter<'a, Handle, Object>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Objects::default` seeds the default authentication key, which is a
+    /// convenient object to replace.
+    fn seeded() -> (Objects, Id, Type) {
+        (
+            Objects::default(),
+            DEFAULT_AUTHENTICATION_KEY_ID,
+            Type::AuthenticationKey,
+        )
+    }
+
+    #[test]
+    fn replace_swaps_the_payload_and_keeps_metadata() {
+        let (mut objects, id, ty) = seeded();
+        let before = objects.get(id, ty).expect("seeded key").object_info.clone();
+
+        let new_key = [0x5au8; 32];
+        assert!(objects.replace(id, ty, &new_key));
+
+        let after = &objects.get(id, ty).expect("key still present").object_info;
+
+        // Metadata is preserved: that is the whole contract of `replace`.
+        assert_eq!(after.object_id, before.object_id);
+        assert_eq!(after.object_type, before.object_type);
+        assert_eq!(after.algorithm, before.algorithm);
+        assert_eq!(after.capabilities, before.capabilities);
+        assert_eq!(after.delegated_capabilities, before.delegated_capabilities);
+        assert_eq!(after.domains, before.domains);
+        assert_eq!(after.label, before.label);
+
+        // The payload is the new key material.
+        assert_eq!(
+            objects
+                .get(id, ty)
+                .unwrap()
+                .payload
+                .authentication_key()
+                .expect("auth key payload")
+                .0,
+            new_key
+        );
+    }
+
+    #[test]
+    fn replace_reports_a_missing_object() {
+        let (mut objects, _, ty) = seeded();
+
+        // Nothing occupies this slot, so there is nothing to replace. Returning
+        // `true` here would let the command handler report success for a key
+        // that does not exist.
+        assert!(!objects.replace(0xbeef, ty, &[0u8; 32]));
+    }
+
+    #[test]
+    fn replace_does_not_create_objects() {
+        let (mut objects, _, ty) = seeded();
+        assert!(!objects.replace(0xbeef, ty, &[0u8; 32]));
+        assert!(objects.get(0xbeef, ty).is_none());
+    }
+}


### PR DESCRIPTION
Replaces the remove-then-`put` workaround introduced with #664 with a dedicated `Objects::replace`.

## Why

`Objects::put` asserts the slot is empty:

```rust
assert!(self.0.insert(handle, object).is_none());
```

That assertion is what made #664 panic outright before it was fixed. The fix at the time was to vacate the slot and re-put, cloning the object's metadata across the gap — which works, but is a workaround for an API that cannot express "replace", and leaves the object briefly absent.

## The shape

Because `ChangeAuthenticationKey` preserves metadata *by definition*, `replace` needs no metadata parameters at all. It reads the algorithm from the object already in the slot and parses the new payload under it:

```rust
pub fn replace(&mut self, object_id: Id, object_type: Type, data: &[u8]) -> bool
```

The handler drops from ~20 lines to 7 and never touches `put`'s assertion.

## No panics

`replace` returns `false` when the slot is empty; the handler maps that to `ObjectNotFound`. This matters beyond tidiness: MockHSM command handlers run while the connector mutex is held, so a panic there poisons it — which is precisely the destructor abort path fixed in #692. Every panic removed from a handler removes a way to reach it.

## Credit

The idea comes from `Objects::replace` in [David Runge's fork](https://crates.io/crates/yubihsm2), which solves the same problem. Two deliberate differences: that version takes the full metadata parameter list, and panics when the target is not an authentication key. This one preserves metadata implicitly and returns an error.

## Verification

Unit tests cover payload replacement with metadata preserved, the missing-object case, and that a failed replace creates nothing. Proven non-vacuous by mutation:

```
replace() as a no-op returning true   -> replace_swaps_the_payload_and_keeps_metadata FAILED
replace() returning true when absent  -> replace_reports_a_missing_object FAILED
                                         replace_does_not_create_objects FAILED
```

Worth noting: the second mutation **passed** against #664's integration tests alone. Nothing exercised the not-found path, which is why the unit tests are here rather than relying on the existing coverage.

```
fmt: PASS   clippy -D warnings: PASS   clippy @1.88 pinned: PASS   doc: PASS
build --no-default-features: PASS   --all-features @1.88 (MSRV): PASS
release + mockhsm,mockhsm-in-release: PASS
cargo test --features=mockhsm,secp256k1,untested: 69 passed, 0 failed
```

(This repo's Actions has produced no runs since 2026-08-05T13:03Z, so the above is local verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
