### PR TITLE
session: do not auto-close a channel that never authenticated

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -141,9 +141,20 @@ impl Session {
     /// # }
     /// ```
     pub fn close(&mut self) -> Result<(), Error> {
-        // Only attempt to close the session if we have an active secure
-        // channel and our session hasn't already timed out
-        if self.secure_channel.is_none() || self.is_timed_out() {
+        // Only close a channel that actually reached `Authenticated`.
+        //
+        // If `Session::open` fails during authentication -- the device rejects
+        // `AuthenticateSession`, or answers it with unexpected data -- the
+        // channel is left unauthenticated or terminated but still present. It
+        // cannot encrypt the close command, and attempting it trips
+        // `encrypt_command`'s assertion inside this destructor. There is also
+        // nothing to release: the HSM never regarded the session as open.
+        let authenticated = self
+            .secure_channel
+            .as_ref()
+            .is_some_and(SecureChannel::is_authenticated);
+
+        if !authenticated || self.is_timed_out() {
             return Ok(());
         }
 
@@ -329,5 +340,71 @@ impl Drop for Session {
                 err
             );
         }
+    }
+}
+
+#[cfg(all(test, feature = "mockhsm", feature = "passwords"))]
+mod tests {
+    use super::*;
+    use crate::authentication;
+    use crate::session::securechannel::Challenge;
+
+    /// A `Session` whose channel never authenticated must not try to close
+    /// itself on drop.
+    ///
+    /// When `Session::open` fails during authentication -- the device rejects
+    /// `AuthenticateSession`, or answers it with unexpected data -- the channel
+    /// is left present but unauthenticated. Closing it reaches
+    /// `SecureChannel::encrypt_command`, which asserts on the security level,
+    /// so the destructor panics and turns a returned error into a crash.
+    #[test]
+    fn dropping_an_unauthenticated_session_does_not_panic() {
+        let channel = SecureChannel::new(
+            Id::from_u8(1).unwrap(),
+            &authentication::Key::default(),
+            Challenge::new(),
+            Challenge::new(),
+        );
+
+        assert!(
+            !channel.is_authenticated(),
+            "a freshly created channel must not be authenticated"
+        );
+
+        let now = Instant::now();
+        let session = Session {
+            id: channel.id(),
+            connector: Connector::mockhsm(),
+            secure_channel: Some(channel),
+            created_at: now,
+            last_active: now,
+            timeout: Timeout::default(),
+        };
+
+        // The assertion under test is that this does not panic.
+        drop(session);
+    }
+
+    /// The same session must also report a clean `close()` rather than panicking.
+    #[test]
+    fn closing_an_unauthenticated_session_is_a_no_op() {
+        let channel = SecureChannel::new(
+            Id::from_u8(1).unwrap(),
+            &authentication::Key::default(),
+            Challenge::new(),
+            Challenge::new(),
+        );
+
+        let now = Instant::now();
+        let mut session = Session {
+            id: channel.id(),
+            connector: Connector::mockhsm(),
+            secure_channel: Some(channel),
+            created_at: now,
+            last_active: now,
+            timeout: Timeout::default(),
+        };
+
+        session.close().expect("closing must not error");
     }
 }

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -200,6 +200,14 @@ impl SecureChannel {
         }
     }
 
+    /// Has this channel completed authentication?
+    ///
+    /// Only an authenticated channel can encrypt commands; the encryption and
+    /// MAC paths assert on this.
+    pub(crate) fn is_authenticated(&self) -> bool {
+        self.security_level == SecurityLevel::Authenticated
+    }
+
     /// Get the channel (i.e. session) ID
     pub fn id(&self) -> session::Id {
         self.id


### PR DESCRIPTION
Fixes a bug introduced by #692, found by the automated review on that PR **after it had already merged**.

## The bug

`Session::open` builds the `Session`, then calls `authenticate`. If authentication fails *after* the secure channel is established, the channel is left present but unauthenticated — `finish_authenticate_session` calls `terminate()`, which sets the security level to `Terminated` without clearing `secure_channel`, and the device-error path in `send_message` doesn't abort either.

The `Session` is then dropped as `open` returns its error, and #692's new destructor closed it. `close` only checked `secure_channel.is_none()`, so it proceeded to `send_command` → `encrypt_command`:

```rust
assert_eq!(self.security_level, SecurityLevel::Authenticated);
```

A returned error becomes a panic inside a destructor. During an existing unwind that's a double panic and aborts the process.

`close` now requires the channel to have reached `Authenticated`. Nothing leaks by skipping it — the HSM never considered the session open.

## Why the obvious test doesn't catch it

Opening a client with a **bad password** passes with or without this fix. That path fails earlier, in `SecureChannel::open`'s cryptogram check, before a `Session` exists to drop. I wrote that test first and it proved nothing.

The real path needed forcing. Making MockHSM return non-empty data for `AuthenticateSession` reproduced it:

```
panicked at src/session/securechannel.rs:294:9:
assertion `left == right` failed
```

The committed tests construct an unauthenticated channel directly instead, so they're deterministic and need no mock surgery. Verified non-vacuous — restoring the previous condition:

```
test closing_an_unauthenticated_session_is_a_no_op ... FAILED
test dropping_an_unauthenticated_session_does_not_panic ... FAILED
  panicked at src/session/securechannel.rs:302:9
```

## Relationship to #692's `panicking()` guard

They cover different halves. The guard added in #692 handles a destructor running *during* an unwind. This handles a destructor running on the normal error-return path, where nothing is unwinding yet but the channel isn't in a state that can encrypt. Both are needed.

## Verification

```
fmt: PASS   clippy -D warnings: PASS   clippy @1.88 pinned: PASS   doc: PASS
build --no-default-features: PASS   --all-features @1.88 (MSRV): PASS
cargo test --features=mockhsm,secp256k1,untested: 68 passed, 0 failed
```

(Actions has produced no runs for this repo since 2026-08-05T13:03Z, so this is local verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
