### PR TITLE
session: release the device-side session after a malformed auth response

### DIFF
--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -757,7 +757,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "passwords"))]
+#[cfg(all(test, feature = "mockhsm", feature = "passwords"))]
 mod auth_response_tests {
     use super::*;
 
@@ -772,7 +772,7 @@ mod auth_response_tests {
     fn malformed_auth_response_leaves_the_channel_closable() {
         let mut channel = SecureChannel::new(
             session::Id::from_u8(1).unwrap(),
-            &crate::authentication::Key::default(),
+            &authentication::Key::default(),
             Challenge::new(),
             Challenge::new(),
         );
@@ -796,7 +796,7 @@ mod auth_response_tests {
     fn well_formed_auth_response_authenticates() {
         let mut channel = SecureChannel::new(
             session::Id::from_u8(1).unwrap(),
-            &crate::authentication::Key::default(),
+            &authentication::Key::default(),
             Challenge::new(),
             Challenge::new(),
         );

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -276,7 +276,19 @@ impl SecureChannel {
     ) -> Result<(), session::Error> {
         // The EXTERNAL_AUTHENTICATE command does not send an R-MAC value
         if !response.data.is_empty() {
-            self.terminate();
+            // Do *not* terminate here. The device answered successfully, so it
+            // has allocated and authenticated this session; the channel keys
+            // are valid and the session exists on the device until closed or
+            // timed out. Zeroizing the keys would make it impossible to send
+            // `CloseSession`, stranding the session for the full timeout and,
+            // across retries, exhausting the device's session pool.
+            //
+            // Mark the channel authenticated -- which it is -- so `Session::close`
+            // can release it, then report the protocol violation to the caller.
+            // `Session::open` still fails, so no usable session escapes.
+            self.security_level = SecurityLevel::Authenticated;
+            self.counter = 1;
+
             fail!(
                 ErrorKind::ProtocolError,
                 "expected empty response data (got {}-bytes)",
@@ -742,5 +754,57 @@ mod tests {
             response.err().unwrap().to_string(),
             "cryptographic verification failed: R-MAC mismatch!"
         );
+    }
+}
+
+#[cfg(all(test, feature = "passwords"))]
+mod auth_response_tests {
+    use super::*;
+
+    /// A successful-but-malformed `AuthenticateSession` response must leave the
+    /// channel able to close itself.
+    ///
+    /// The device allocates and authenticates the session before replying, so
+    /// it exists device-side until closed or timed out. Zeroizing the keys here
+    /// would make `CloseSession` impossible, stranding it for the full timeout
+    /// and, across retries, exhausting the 16-session pool.
+    #[test]
+    fn malformed_auth_response_leaves_the_channel_closable() {
+        let mut channel = SecureChannel::new(
+            session::Id::from_u8(1).unwrap(),
+            &crate::authentication::Key::default(),
+            Challenge::new(),
+            Challenge::new(),
+        );
+
+        let response = response::Message::success(command::Code::AuthenticateSession, vec![0xAA]);
+
+        let err = channel
+            .finish_authenticate_session(&response)
+            .expect_err("unexpected response data must be reported");
+        assert_eq!(*err.kind(), ErrorKind::ProtocolError);
+
+        assert!(
+            channel.is_authenticated(),
+            "the channel must remain able to encrypt CloseSession so the \
+             device-side session can be released"
+        );
+    }
+
+    /// A well-formed response still authenticates.
+    #[test]
+    fn well_formed_auth_response_authenticates() {
+        let mut channel = SecureChannel::new(
+            session::Id::from_u8(1).unwrap(),
+            &crate::authentication::Key::default(),
+            Challenge::new(),
+            Challenge::new(),
+        );
+
+        let response = response::Message::success(command::Code::AuthenticateSession, vec![]);
+        channel
+            .finish_authenticate_session(&response)
+            .expect("a well-formed response must authenticate");
+        assert!(channel.is_authenticated());
     }
 }


### PR DESCRIPTION
Follow-up to #699, from the automated review on that PR **after it merged**. Verified before acting — both halves of the claim hold.

## The problem

`AuthenticateSession` can succeed on the device while its response carries unexpected data. `verify_authenticate_session` sets the device-side channel to `Authenticated` and returns success *before* we inspect the body, so at that point the session is allocated and authenticated on the device.

Our side then called `terminate()`, which zeroizes the session keys:

```rust
fn terminate(&mut self) {
    self.security_level = SecurityLevel::Terminated;
    self.enc_key.zeroize();
    self.mac_key.zeroize();
    self.rmac_key.zeroize();
}
```

`CloseSession` has to be encrypted, so with the keys gone it cannot be sent. #699's guard then correctly declines to close — and the session is stranded until the 30-second timeout. Across retries that exhausts the device's 16-session pool, which is the same failure mode as #495.

## The fix

The channel is genuinely usable at that point: the keys are valid and the device authenticated. So mark it authenticated rather than terminating, let `Session::close` release the session, and still return the protocol error.

`Session::open` fails either way, so no usable session escapes to the caller — the `Session` is dropped and the `Drop` handler closes it.

## Relationship to #699

They cover different states. #699 stops us closing a channel that **never authenticated** (where `encrypt_command` would assert). This one ensures a channel that **did** authenticate gets closed rather than abandoned. #699's tests still pass unchanged.

## Verification

Non-vacuous — restoring the `terminate()` call:

```
test malformed_auth_response_leaves_the_channel_closable ... FAILED
test well_formed_auth_response_authenticates ... ok
```

```
fmt: PASS   clippy -D warnings: PASS   clippy @1.88 pinned: PASS   doc: PASS
build --no-default-features: PASS   --all-features @1.88 (MSRV): PASS
cargo test --features=mockhsm,secp256k1,untested: 84 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
