### PR TITLE
Add support for getting device info without authentication

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -29,8 +29,14 @@ pub use self::connection::Connection;
 pub use self::error::*;
 
 pub(crate) use self::{connectable::Connectable, message::Message};
+use crate::{
+    command, device,
+    device::commands::DeviceInfoResponse,
+    response,
+    serialization::deserialize,
+    uuid::{self, Uuid},
+};
 use std::sync::{Arc, Mutex};
-use uuid::Uuid;
 
 #[cfg(feature = "http")]
 pub use self::http::HttpConfig;
@@ -95,6 +101,45 @@ impl Connector {
                 // In the event of an error, mark this connection as invalid
                 *connection = None;
             })
+    }
+
+    /// Get information about the HSM device *without* establishing a session.
+    ///
+    /// The response is **not authenticated**. A session response is R-MAC'd
+    /// under the SCP03 session keys, so it is provably from the device and
+    /// provably fresh; this one is not, so anything on the path between this
+    /// process and the device can forge or replay it. Treat these values as a
+    /// hint, never as evidence. Use [`Client::device_info`] when the answer has
+    /// to be trustworthy.
+    ///
+    /// <https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#get-device-info-command>
+    ///
+    /// [`Client::device_info`]: crate::Client::device_info
+    pub fn device_info(&self) -> Result<device::Info, Error> {
+        let command = command::Message::create(command::Code::DeviceInfo, vec![])
+            .map_err(|e| ErrorKind::RequestError.context(e))?;
+
+        let response = response::Message::parse(self.send_message(uuid::new_v4(), command.into())?)
+            .map_err(|e| ErrorKind::ResponseError.context(e))?;
+
+        if response.is_err() {
+            match device::ErrorKind::from_response_message(&response) {
+                Some(kind) => fail!(ErrorKind::ResponseError, "HSM error: {}", kind),
+                None => fail!(ErrorKind::ResponseError, "HSM error: {:?}", response.code),
+            }
+        }
+
+        if response.command() != Some(command::Code::DeviceInfo) {
+            fail!(
+                ErrorKind::ResponseError,
+                "unexpected response type: {:?}",
+                response.code
+            );
+        }
+
+        Ok(deserialize::<DeviceInfoResponse>(&response.data)
+            .map_err(|e| ErrorKind::ResponseError.context(e))?
+            .into())
     }
 }
 

--- a/tests/command/device_info.rs
+++ b/tests/command/device_info.rs
@@ -11,3 +11,20 @@ fn device_info_test() {
     // depending on the specific YubiHSM 2 model.
     assert_eq!(device_info.major_version, 2);
 }
+
+/// Get device information without opening a session
+#[test]
+fn unauthenticated_device_info_test() {
+    let device_info = crate::HSM_CONNECTOR
+        .device_info()
+        .unwrap_or_else(|err| panic!("error getting unauthenticated device info: {err}"));
+
+    assert_eq!(device_info.major_version, 2);
+    assert!(device_info.log_store_capacity > 0);
+
+    // The unauthenticated answer should agree with the session's. (It is not
+    // authenticated, so a mismatch means something on the path is rewriting it.)
+    let session_info = crate::get_hsm_client().device_info().unwrap();
+    assert_eq!(device_info.serial_number, session_info.serial_number);
+    assert_eq!(device_info.major_version, session_info.major_version);
+}


### PR DESCRIPTION
`GetDeviceInfo` is one of the few commands a YubiHSM 2 will answer outside of an authenticated session, and the device writes no audit log entry for it. That makes it usable for discovery and health checks against a device you hold no credentials for, and because the response carries `log_store_used` for deciding whether opening a session (which *is* audited, and consumes entries from the device's small circular log buffer) is worth it at all.

Complements #676, resolves #607.