### PR TITLE
session: expose derive_keys

### DIFF
--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -110,6 +110,24 @@ impl SessionKeys {
             rmac_key,
         }
     }
+
+    /// Obtain the session encryption key (S-ENC).
+    #[inline]
+    pub fn enc_key(&self) -> &[u8; KEY_SIZE] {
+        &self.enc_key
+    }
+
+    /// Obtain the session command MAC key (S-MAC).
+    #[inline]
+    pub fn mac_key(&self) -> &[u8; KEY_SIZE] {
+        &self.mac_key
+    }
+
+    /// Obtain the session response MAC key (S-RMAC).
+    #[inline]
+    pub fn rmac_key(&self) -> &[u8; KEY_SIZE] {
+        &self.rmac_key
+    }
 }
 
 /// SCP03 Secure Channel
@@ -181,15 +199,7 @@ impl SecureChannel {
         card_challenge: Challenge,
     ) -> Self {
         let context = Context::from_challenges(host_challenge, card_challenge);
-        let enc_key = derive_key(authentication_key.enc_key(), 0b100, &context);
-        let mac_key = derive_key(authentication_key.mac_key(), 0b110, &context);
-        let rmac_key = derive_key(authentication_key.mac_key(), 0b111, &context);
-
-        let session_keys = SessionKeys {
-            enc_key,
-            mac_key,
-            rmac_key,
-        };
+        let session_keys = context.derive_keys(authentication_key);
         Self::with_session_keys(id, context, session_keys)
     }
 

--- a/src/session/securechannel/context.rs
+++ b/src/session/securechannel/context.rs
@@ -1,6 +1,7 @@
 //! Derivation context (i.e. concatenated challenges)
 
-use super::{Challenge, CHALLENGE_SIZE};
+use super::{derive_key, Challenge, SessionKeys, CHALLENGE_SIZE};
+use crate::authentication;
 
 /// Size of a session context
 const CONTEXT_SIZE: usize = CHALLENGE_SIZE * 2;
@@ -28,5 +29,18 @@ impl Context {
     /// Borrow the context value as a slice
     pub fn as_slice(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Derive session keys from context and authentication key
+    pub fn derive_keys(&self, authentication_key: &authentication::Key) -> SessionKeys {
+        let enc_key = derive_key(authentication_key.enc_key(), 0b100, self);
+        let mac_key = derive_key(authentication_key.mac_key(), 0b110, self);
+        let rmac_key = derive_key(authentication_key.mac_key(), 0b111, self);
+
+        SessionKeys {
+            enc_key,
+            mac_key,
+            rmac_key,
+        }
     }
 }


### PR DESCRIPTION
This a follow up on https://github.com/iqlusioninc/yubihsm.rs/pull/570 that got closed.

This allows to split the derivation of session keys with the HSM on a separate process with reduced lifespan/more restricted feature set.